### PR TITLE
fix: resolve gpu sensor initialization error

### DIFF
--- a/collector/src/sensors/gpu.rs
+++ b/collector/src/sensors/gpu.rs
@@ -183,6 +183,7 @@ mod amd_gpu {
     use crate::database::{GPUData, SensorData};
 
     pub struct AmdGPUSensor {
+        _helper: AdlxHelper,
         gpu_metrics: GpuMetrics,
     }
 
@@ -200,7 +201,10 @@ mod amd_gpu {
                 .current_gpu_metrics(&gpu)
                 .map_err(|e| SensorError::ReadError(e.to_string()))?;
 
-            Ok(AmdGPUSensor { gpu_metrics })
+            Ok(AmdGPUSensor {
+                _helper: helper,
+                gpu_metrics,
+            })
         }
     }
 


### PR DESCRIPTION
## Description

The access violation appears to come from a lifetime bug in collector/src/sensors/gpu.rs: AdlxHelper is dropped at the end of AmdGPUSensor::new, but gpu_metrics keeps ADLX interface pointers that become invalid. I’m applying a small fix to keep the ADLX helper alive inside the sensor.

## Related issue

Closes #32 

## Checklist

- [x] `cargo build` passes
- [x] `cargo +nightly fmt` applied
- [x] Changes are scoped to the described issue
