### PR TITLE
Add new mode headless

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@
 - [ ] Run as a service ([#18](https://github.com/Daminoup88/WattSeal/issues/18))
 - [ ] Configurable sensors polling frequency with no regression on purge / UI averages ([46](https://github.com/Daminoup88/WattSeal/issues/46))
 - [ ] Improved estimation of energy consumption on machines with Apple Silicon processors ([46](https://github.com/Daminoup88/WattSeal/issues/46))
-- [ ] Add the possibility to run only sensors by implementing a headless mode ([46](https://github.com/Daminoup88/WattSeal/issues/46))
+- [x] Add the possibility to run only sensors by implementing a headless mode ([52](https://github.com/Daminoup88/WattSeal/issues/52))
 
 ### Security
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use winit::{
 struct Options {
     ui_mode: bool,
     background_mode: bool,
+    headless_mode: bool,
 }
 
 /// Returns options parser to run
@@ -43,9 +44,15 @@ fn options() -> OptionParser<Options> {
         )
         .flag(true, false);
 
+    let headless_mode = short('h')
+        .long("headless")
+        .help("Runs only Wattseal sensors, without UI and tray icon.")
+        .flag(true, false);
+
     construct!(Options {
         ui_mode,
         background_mode,
+        headless_mode,
     })
     .to_options()
 }
@@ -185,6 +192,12 @@ fn main() {
         }
     }
 
+    if options.headless_mode && (options.ui_mode || options.background_mode) {
+        let msg = format!("Impossible to run headless mode if UI or background mode is enabled");
+        common::clog!("✗ {msg}");
+        return;
+    }
+
     if options.ui_mode {
         if let Err(err) = ui::run() {
             common::clog!("✗ UI failed to start: {err}");
@@ -234,6 +247,10 @@ fn main() {
             common::clog!("✗ Collector thread ended before signaling readiness: {}", e);
             return;
         }
+    }
+
+    if options.headless_mode {
+        loop {}
     }
 
     let ui_child: Arc<Mutex<Option<Child>>> = Arc::new(Mutex::new(None));

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use bpaf::*;
+use bpaf::{OptionParser, Parser, construct, long, short};
 use collector::CollectorApp;
 use common::WINDOW_ICON_BYTES;
 use tray_icon::{
@@ -38,14 +38,14 @@ fn options() -> OptionParser<Options> {
 
     let background_mode = short('b')
         .long("background")
+        .long("bg")
         .help(
             "Runs Wattseal in the background. It's possible to return to the
             UI mode from the tray icons",
         )
         .flag(true, false);
 
-    let headless_mode = short('h')
-        .long("headless")
+    let headless_mode = long("headless")
         .help("Runs only Wattseal sensors, without UI and tray icon.")
         .flag(true, false);
 
@@ -55,6 +55,7 @@ fn options() -> OptionParser<Options> {
         headless_mode,
     })
     .to_options()
+    .descr("WattSeal - Per-app power monitoring tool")
 }
 
 /// Spawns the UI subprocess if not already running.
@@ -172,6 +173,14 @@ fn run_linux_tray(ui_child: &Arc<Mutex<Option<Child>>>) -> bool {
     true
 }
 
+/// Initializes the collector
+fn start_collector() -> Result<CollectorApp, String> {
+    let mut app = CollectorApp::new().map_err(|e| format!("Failed to create CollectorApp: {e}"))?;
+    app.initialize()
+        .map_err(|e| format!("Failed to initialize CollectorApp: {e}"))?;
+    Ok(app)
+}
+
 fn main() {
     if let Err(e) = common::set_current_dir_to_exe_dir() {
         common::clog!("⚠ Failed to set working directory to executable directory: {}", e);
@@ -214,25 +223,27 @@ fn main() {
         }
     };
 
+    if options.headless_mode {
+        match start_collector() {
+            Ok(mut app) => app.run(),
+            Err(e) => common::clog!("✗ {e}"),
+        }
+        return;
+    }
+
+    // Doesn't run in headless mode
     let (tx, rx) = mpsc::channel::<Result<(), String>>();
 
     thread::spawn(move || {
-        let mut app = match CollectorApp::new() {
+        let mut app = match start_collector() {
             Ok(app) => app,
             Err(e) => {
-                let msg = format!("Failed to create CollectorApp: {e}");
-                common::clog!("✗ {msg}");
-                let _ = tx.send(Err(msg));
+                common::clog!("✗ {e}");
+                let _ = tx.send(Err(e));
                 return;
             }
         };
-        if let Err(e) = app.initialize() {
-            let msg = format!("Failed to initialize CollectorApp: {e}");
-            common::clog!("✗ {msg}");
-            let _ = tx.send(Err(msg));
-            return;
-        }
-        tx.send(Ok(())).unwrap_or_default();
+        let _ = tx.send(Ok(()));
         app.run();
     });
 
@@ -247,10 +258,6 @@ fn main() {
             common::clog!("✗ Collector thread ended before signaling readiness: {}", e);
             return;
         }
-    }
-
-    if options.headless_mode {
-        loop {}
     }
 
     let ui_child: Arc<Mutex<Option<Child>>> = Arc::new(Mutex::new(None));


### PR DESCRIPTION
## Description

Add new mode headless.

## Related issue

Closes #52 

## Changes

- Add new option headless.
- Add the possibility to only run sensors with this new option/

## Checklist

- [x] `cargo build` passes
- [x] `cargo +nightly fmt` applied
- [x] Changes are scoped to the described issue