### PR TITLE
No winring0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,8 +132,8 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -264,8 +264,8 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -299,8 +299,8 @@ version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -520,8 +520,8 @@ version = "0.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549ca9c364fdc06f9f36d1356980193d930abc80db848193c2dd4d0e9a83de1b"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -552,8 +552,8 @@ version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -782,13 +782,12 @@ dependencies = [
  "chrono",
  "common",
  "display-info",
- "is-admin",
  "mqtt",
  "nvml-wrapper",
  "rumqttc",
+ "runas",
+ "scaphandre-driver-rs",
  "sysinfo",
- "win-kernel-driver",
- "win_ring0",
  "windows 0.62.2",
 ]
 
@@ -1045,8 +1044,8 @@ checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "strsim",
  "syn 2.0.117",
 ]
@@ -1058,7 +1057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
- "quote 1.0.45",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1130,7 +1129,7 @@ dependencies = [
  "scopeguard",
  "smithay-client-toolkit 0.20.0",
  "thiserror 2.0.18",
- "widestring 1.2.1",
+ "widestring",
  "windows 0.62.2",
  "xcb",
 ]
@@ -1217,8 +1216,8 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1237,8 +1236,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1247,19 +1246,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "err-derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d8ff65eb6c2fc68e76557239d16f5698fd56603925b89856d3f0f7105fd4543"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "rustc_version 0.2.3",
- "syn 0.15.44",
- "synstructure",
-]
 
 [[package]]
 name = "errno"
@@ -1365,8 +1351,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1386,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
- "rustc_version 0.4.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1551,8 +1537,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1665,8 +1651,8 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1964,8 +1950,8 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro-crate 2.0.2",
  "proc-macro-error",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1977,8 +1963,8 @@ checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate 3.5.0",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -2143,8 +2129,8 @@ checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -2553,18 +2539,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "is-admin"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c36aab4b571b8689441fcf2b07962edd22b10aed28d2f71bcc64515f6b317df"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2646,9 +2623,9 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
- "rustc_version 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
 ]
@@ -2677,7 +2654,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
- "quote 1.0.45",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3093,8 +3070,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3299,8 +3276,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3351,8 +3328,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate 3.5.0",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3947,7 +3924,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
- "rustc_version 0.4.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -3990,8 +3967,8 @@ version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4191,7 +4168,7 @@ version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
- "proc-macro2 1.0.106",
+ "proc-macro2",
  "syn 2.0.117",
 ]
 
@@ -4231,8 +4208,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -4243,18 +4220,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -4281,7 +4249,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
- "quote 1.0.45",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4326,20 +4294,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
- "proc-macro2 1.0.106",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -4635,20 +4594,11 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -4761,6 +4711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scaphandre-driver-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d659d55e0eef145f9222fbe444fc9f356a7766c7ffe118c3a8f6034e655392c"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4825,24 +4784,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -4869,8 +4813,8 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4893,8 +4837,8 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4944,7 +4888,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "rustc_version 0.4.1",
+ "rustc_version",
  "simdutf8",
 ]
 
@@ -4954,7 +4898,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
- "quote 1.0.45",
+ "quote",
 ]
 
 [[package]]
@@ -5205,22 +5149,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.106",
+ "proc-macro2",
  "unicode-ident",
 ]
 
@@ -5230,21 +5163,9 @@ version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -5361,8 +5282,8 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -5372,8 +5293,8 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -5465,8 +5386,8 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -5627,8 +5548,8 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -5743,12 +5664,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -5875,7 +5790,7 @@ version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
- "quote 1.0.45",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5886,8 +5801,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
@@ -5932,7 +5847,7 @@ dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -5959,8 +5874,6 @@ dependencies = [
  "common",
  "gtk",
  "image 0.25.10",
- "is-admin",
- "runas",
  "tray-icon",
  "ui",
  "winit",
@@ -6085,9 +5998,9 @@ version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
- "proc-macro2 1.0.106",
+ "proc-macro2",
  "quick-xml 0.39.2",
- "quote 1.0.45",
+ "quote",
 ]
 
 [[package]]
@@ -6293,36 +6206,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a212922ea58fbf5044f83663aa4fc6281ff890f1fd7546c0c3f52f5290831781"
-
-[[package]]
-name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
-name = "win-kernel-driver"
-version = "0.0.1"
-source = "git+https://github.com/alex-dow/winRing0-rs#f26aa05277f4989db26f846953285edd8aa3d631"
-dependencies = [
- "err-derive",
- "winapi",
- "windows-service",
-]
-
-[[package]]
-name = "win_ring0"
-version = "0.0.1"
-source = "git+https://github.com/alex-dow/winRing0-rs#f26aa05277f4989db26f846953285edd8aa3d631"
-dependencies = [
- "err-derive",
- "win-kernel-driver",
- "winapi",
- "windows-service",
-]
 
 [[package]]
 name = "winapi"
@@ -6443,8 +6329,8 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -6454,8 +6340,8 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -6465,8 +6351,8 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -6476,8 +6362,8 @@ version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -6513,18 +6399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-service"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048b185a91d03beafe88c5db975c42c12b9462bc939f92ca863c88785a33a6ab"
-dependencies = [
- "bitflags 1.3.2",
- "err-derive",
- "widestring 0.3.0",
- "winapi",
 ]
 
 [[package]]
@@ -6919,8 +6793,8 @@ checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
  "prettyplease",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
@@ -6955,11 +6829,11 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid 0.2.6",
+ "unicode-xid",
  "wasmparser",
 ]
 
@@ -6970,8 +6844,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
 dependencies = [
  "darling",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -7114,8 +6988,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
 dependencies = [
  "proc-macro-crate 3.5.0",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
  "zbus_names",
  "zvariant",
@@ -7154,8 +7028,8 @@ version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -7216,8 +7090,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
 dependencies = [
  "proc-macro-crate 3.5.0",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
  "zvariant_utils",
 ]
@@ -7228,8 +7102,8 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "serde",
  "syn 2.0.117",
  "winnow 0.7.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.9.25"
+version = "0.9.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8d4b90317451025bfa1f7d359a5fa698a5f745927ff27696429b7fbd7c0c48"
+checksum = "0b86829876e7e200161a5aa6ea688d46c32d64d70ee3100127790dde84688d6e"
 dependencies = [
  "bpaf_derive",
  "owo-colors",
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "bpaf_derive"
-version = "0.5.23"
+version = "0.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ca9c364fdc06f9f36d1356980193d930abc80db848193c2dd4d0e9a83de1b"
+checksum = "2f7e98cee839b19076cb3ce1afdb62bb182e04ff5f71f70188827002fae91094"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3771,9 +3771,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
-version = "5.3.4"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "is-wsl",
  "libc",
@@ -5179,9 +5179,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9f9fe3d2b7b75cf4f2805e5b9926e8ac47146667b16b86298c4a8bf08cc469"
+checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
 dependencies = [
  "libc",
  "memchr",
@@ -5564,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
+checksum = "e47e6d063cfe4ad2e416fcbb310be3a37c5fd85c745b62cb562bfa4a003df674"
 dependencies = [
  "crossbeam-channel",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,6 @@ winit = "0.30.13"
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"
 
-[target.'cfg(windows)'.dependencies]
-is-admin = "0.1.4"
-runas = "1.2"
-
 [profile.release]
 opt-level = 3
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ image = { version = "0.25", default-features = false, features = ["png", "ico"] 
 collector = { path = "collector" }
 ui = { path = "ui" }
 common = { path = "common" }
-tray-icon = { version = "0.23.1", default-features = false }
+tray-icon = { version = "0.24.0", default-features = false, features = ["gtk"] }
 chrono = "0.4.44"
 image = { version = "0.25", default-features = false, features = ["png"] }
-bpaf = { version = "0.9.25", features = ["derive", "dull-color"] }
+bpaf = { version = "0.9.26", features = ["derive", "dull-color"] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 winit = "0.30.13"

--- a/README.md
+++ b/README.md
@@ -49,18 +49,16 @@ WattSeal is a single executable file — no installation needed. Just download i
 
 ### Step 2 — Run it
 
-WattSeal doesn't need administrative privileges to run, but it does need them for precise CPU power measurements. If you skip the admin step, you'll still get power estimates based on CPU usage, but they won't be as accurate.
+WattSeal doesn't need administrative privileges to run, but Windows needs a one-time admin step to install the CPU MSR driver for precise power measurements. If you skip that step, you'll still get power estimates based on CPU usage, but they won't be as accurate.
 
 <details>
 <summary><strong>🪟 Windows</strong></summary>
 
 1. Double-click the downloaded `WattSeal-windows-x86_64.exe` file
 2. If prompted by Windows Defender SmartScreen, click "More info" and then "Run anyway" to launch the app. This is a standard warning for new apps that haven't yet built up reputation on Windows.
-3. If prompted by User Account Control (UAC), and you want the most accurate CPU power readings, click "Yes" to allow it to run with administrator privileges. If you click "No", it will still work but with less precise CPU power estimates.
+3. If prompted by User Account Control (UAC) to install the CPU MSR driver, click "Yes" to install it (this is a one-time step). If you click "No", WattSeal will still run but CPU power readings will be estimated.
 
 The app will launch in the system tray in the taskbar and the dashboard will open in a new window. If you close the dashboard, WattSeal will keep running in the background and you can reopen it by clicking the tray icon.
-
-If the app, or more especifically the WinRing0 kernel driver it uses for CPU measurements, is flagged by Windows Defender, it's your responsibility to allow it to run. The app will run without admin privileges, but CPU power readings will be estimates based on usage rather than direct hardware counters. For more info on the security implications of WinRing0, see the [Security](SECURITY.md#winring0-kernel-driver-windows) section of the documentation.
 
 </details>
 
@@ -120,7 +118,7 @@ With admin privileges, WattSeal provides the most comprehensive power monitoring
 | AMD GPU | ✅ | ❌ | ❌ |
 | Intel GPU | ✅ | ❌ | ❌ |
 | Other sensors (usage, I/O) | ✅ | ✅ | ✅ |
-| Auto admin elevation | ✅ UAC | Manual (`sudo`) | Manual |
+| Auto admin elevation | ✅ UAC (one time) | Manual (`sudo`) | Manual |
 
 <details>
 <summary><strong>Support without admin privileges</strong></summary>
@@ -128,7 +126,7 @@ With admin privileges, WattSeal provides the most comprehensive power monitoring
 |  | Windows | Linux | macOS |
 |---|:---:|:---:|:---:|
 | Full application | ✅ | ✅ | ✅ |
-| CPU energy counters | Estimated | Estimated | Estimated |
+| CPU energy counters | ✅ (after driver install) | Estimated | Estimated |
 | NVIDIA GPU | ✅ | ✅ | ❌ |
 | AMD GPU | ✅ | ❌ | ❌ |
 | Intel GPU | ✅ | ❌ | ❌ |
@@ -209,8 +207,8 @@ Release build:
 cargo build --release
 ```
 
-> ⚠️ **Elevated privileges are required** to access hardware energy counters.
-> Run with administrator rights on Windows (you will be prompted to elevate), or use `sudo` on Linux.
+> ⚠️ **Elevated privileges are required** only to install the Windows CPU MSR driver once.
+> Run with administrator rights on Windows (you will be prompted to elevate for driver setup), or use `sudo` on Linux for RAPL access.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@
 
 ### Security
 
-- [ ] Remove WinRing0 driver dependency on Windows (see [Security](SECURITY.md#winring0-kernel-driver-windows) section for details) ([#19](https://github.com/Daminoup88/WattSeal/issues/19))
+- [x] Remove WinRing0 driver dependency on Windows (see [Security](SECURITY.md#winring0-kernel-driver-windows) section for details) ([#19](https://github.com/Daminoup88/WattSeal/issues/19))
 
 ## Data integration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,44 +14,32 @@ We'll acknowledge your report within 48 hours and work with you to understand an
 
 ## Scope
 
-WattSeal runs with elevated privileges (admin/root) to access hardware energy counters. We take this responsibility seriously.
+WattSeal may request elevated privileges to install a Windows CPU driver or to access Linux RAPL counters. We take this responsibility seriously.
 
 ---
 
-## WinRing0 Kernel Driver (Windows)
+## Scaphandre RAPL Driver (Windows)
 
-On Windows, WattSeal uses **WinRing0**, a third-party signed kernel-mode driver, to read CPU Model Specific Registers (MSRs). This is currently the only mechanism available to access hardware RAPL energy counters on Windows without building a custom kernel driver (that would be flagged by Windows Defender if not signed). Precise CPU measurements are a core requirement of WattSeal — without them the application cannot fulfil its primary purpose.
+On Windows, WattSeal uses the **Scaphandre RAPL driver**, a minimal signed kernel-mode driver, to read CPU Model Specific Registers (MSRs) required for RAPL energy counters. This replaces the previous generic MSR driver and reduces the exposed surface to the read-only operations WattSeal needs.
 
 ### Why it exists
 
-Reading CPU energy registers on Windows requires Ring-0 (kernel) access. WinRing0 is the only widely available signed driver that provides this without requiring test-signing mode. WattSeal uses it in a strictly read-only, targeted manner.
+Reading CPU energy registers on Windows requires Ring-0 (kernel) access. The Scaphandre driver provides read-only MSR access focused on RAPL counters, avoiding the generic read/write capabilities of legacy drivers.
 
 ### Security implications
 
-Kernel drivers run at the highest privilege level on the system. WinRing0 exposes generic MSR read/write capability, which goes beyond WattSeal's own read-only needs. This represents an elevated attack surface. While WattSeal constrains its own use of the driver, it cannot fully control what the driver exposes to other processes on the system.
+Kernel drivers run at the highest privilege level on the system. While the Scaphandre driver is minimal and read-only, it is still privileged code. WattSeal installs it once and then accesses it from user mode; normal operation does not require elevated privileges.
 
-WattSeal does not install WinRing0 as a permanent service. The driver is loaded on demand and its lifecycle is managed by the application. However, driver registration requires writing to the Windows registry and placing the `.sys` file on disk.
+### Installing and removing the driver
 
-### We want to replace it
+To install the driver:
 
-We are actively seeking a safer alternative — a minimal purpose-built signed driver or an official Windows API. **Contributions and suggestions toward this goal are very welcome.** Until a replacement exists, WinRing0 remains a necessary dependency for full measurement accuracy.
+1. Run `WattSeal --install-cpu-driver` **as Administrator**.
 
-### Your responsibility
+To remove the driver:
 
-By running WattSeal as administrator on Windows and accepting the UAC prompt, **you explicitly consent to loading a third-party kernel-mode driver.** You are responsible for this decision. If you are not comfortable with it, you may run WattSeal without administrator privileges — CPU power readings will fall back to estimates, but no kernel driver will be loaded.
+1. Run `WattSeal --uninstall-cpu-driver` **as Administrator**.
 
-### Removing WinRing0
+### Reporting driver-related issues
 
-If WinRing0 has been loaded by WattSeal and you wish to remove it entirely:
-
-1. Open PowerShell **as Administrator**.
-2. Stop and remove the service:
-   ```powershell
-   sc.exe stop WinRing0_1_2_0
-   sc.exe delete WinRing0_1_2_0
-   ```
-3. **Reboot** to fully unload the driver from kernel memory.
-
-### Reporting WinRing0-related issues
-
-If you discover a security vulnerability related to how WattSeal loads or uses WinRing0, or if you know of a safer alternative that could replace it, please report it through the process above or open a GitHub discussion. We treat any such report as high priority.
+If you discover a security vulnerability related to how WattSeal loads or uses the Scaphandre driver, please report it through the process above. We treat any such report as high priority.

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -4,10 +4,9 @@ version.workspace = true
 edition = "2024"
 
 [target.'cfg(windows)'.dependencies]
-win-kernel-driver = { git = "https://github.com/alex-dow/winRing0-rs" }
-win_ring0 = { git = "https://github.com/alex-dow/winRing0-rs" }
+scaphandre-driver-rs = "1.0.0"
 adlx = "0.0.0-alpha.1"
-is-admin = "0.1.4"
+runas = "1.2"
 windows = { version = "0.62.2", features = [
     "Win32_Graphics_Dxgi",
     "Win32_Foundation",

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -25,6 +25,6 @@ common = { path = "../common" }
 mqtt = { path = "../mqtt" }
 display-info = "0.5.9"
 chrono = "0.4.44"
-sysinfo = "0.39.0"
+sysinfo = "0.39.1"
 battery = "0.7.8"
 rumqttc = "0.25.1"

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -83,8 +83,6 @@ impl CollectorApp {
 
     /// Detects hardware sensors, creates database tables, and saves hardware info.
     pub fn initialize(&mut self) -> Result<(), String> {
-        let is_admin = is_admin();
-
         #[cfg(not(debug_assertions))]
         start_log_session();
 
@@ -92,8 +90,12 @@ impl CollectorApp {
 
         // CPU sensor
         clog!("Initializing sensors...");
-        match sensors::cpu::get_cpu_power_sensor(self.system.clone(), 0, is_admin) {
+        match sensors::cpu::get_cpu_power_sensor(self.system.clone(), 0) {
             Ok(sensor) => {
+                if let SensorType::CPU(cpu_sensor) = &sensor {
+                    let (os_label, mode_label) = cpu_sensor.power_mode_labels();
+                    clog!("CPU power mode: {os_label}/{mode_label}");
+                }
                 clog!("✓ CPU Power Sensor initialized successfully");
                 self.sensors.push(sensor);
             }
@@ -228,36 +230,5 @@ impl CollectorApp {
                 thread::sleep(Duration::from_millis(1000 - now_sub_ms as u64));
             }
         }
-    }
-}
-
-/// Returns whether the current process has elevated/RAPL privileges.
-fn is_admin() -> bool {
-    #[cfg(target_os = "windows")]
-    {
-        let admin = is_admin::is_admin();
-        #[cfg(debug_assertions)]
-        if !admin {
-            eprintln!("\u{26a0} Running without Administrator privileges. CPU power readings will use estimation.");
-        }
-        admin
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        let rapl_accessible = std::fs::read_to_string("/sys/class/powercap/intel-rapl:0/energy_uj").is_ok();
-        #[cfg(debug_assertions)]
-        if !rapl_accessible {
-            eprintln!("\u{26a0} RAPL not accessible. CPU power readings will use estimation.");
-            eprintln!("  Tip: run as root or grant read access to /sys/class/powercap/");
-        }
-        rapl_accessible
-    }
-
-    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
-    {
-        #[cfg(debug_assertions)]
-        eprintln!("\u{26a0} No privileged power-reading support on this platform. Using estimation.");
-        false
     }
 }

--- a/collector/src/sensors/cpu/mod.rs
+++ b/collector/src/sensors/cpu/mod.rs
@@ -10,7 +10,7 @@ mod estimation;
 #[cfg(target_os = "linux")]
 mod linux_cpu;
 #[cfg(target_os = "windows")]
-mod windows_cpu;
+pub mod windows_cpu;
 
 use estimation::EstimationCPUSensor;
 pub use estimation::estimate_igpu_power;
@@ -22,9 +22,9 @@ use windows_cpu::WindowsCPUSensor;
 /// Platform-specific CPU power source.
 pub enum CPUOS {
     #[cfg(target_os = "windows")]
-    Windows(WindowsCPUSensor),
+    WindowsRAPL(WindowsCPUSensor),
     #[cfg(target_os = "linux")]
-    Linux(LinuxCPUSensor),
+    LinuxRAPL(LinuxCPUSensor),
     Estimation(EstimationCPUSensor),
 }
 
@@ -32,6 +32,18 @@ pub enum CPUOS {
 pub struct CPUSensor {
     sensor: CPUOS,
     system: Rc<RefCell<System>>,
+}
+
+impl CPUSensor {
+    pub fn power_mode_labels(&self) -> (&'static str, &'static str) {
+        match &self.sensor {
+            #[cfg(target_os = "windows")]
+            CPUOS::WindowsRAPL(_) => ("windows", "scaphandre"),
+            #[cfg(target_os = "linux")]
+            CPUOS::LinuxRAPL(_) => ("linux", "rapl"),
+            CPUOS::Estimation(_) => ("estimation", "tdp"),
+        }
+    }
 }
 
 impl Sensor for CPUSensor {
@@ -48,9 +60,9 @@ impl Sensor for CPUSensor {
 
         let mut power_data = match &self.sensor {
             #[cfg(target_os = "windows")]
-            CPUOS::Windows(sensor) => sensor.read_full_data()?,
+            CPUOS::WindowsRAPL(sensor) => sensor.read_full_data()?,
             #[cfg(target_os = "linux")]
-            CPUOS::Linux(sensor) => sensor.read_full_data()?,
+            CPUOS::LinuxRAPL(sensor) => sensor.read_full_data()?,
             CPUOS::Estimation(sensor) => SensorData::CPU(CPUData {
                 total_power_watts: Some(sensor.estimate(usage_percent)),
                 pp0_power_watts: None,
@@ -148,11 +160,7 @@ pub fn get_cpu_list(system: Rc<RefCell<System>>) -> Result<Vec<String>, String> 
 }
 
 /// Creates the best available CPU power sensor, falling back to TDP estimation.
-pub fn get_cpu_power_sensor(
-    system: Rc<RefCell<System>>,
-    index: usize,
-    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] is_admin: bool,
-) -> Result<SensorType, SensorError> {
+pub fn get_cpu_power_sensor(system: Rc<RefCell<System>>, index: usize) -> Result<SensorType, SensorError> {
     let s = system
         .try_borrow_mut()
         .map_err(|e| SensorError::ReadError(format!("Failed to borrow system: {}", e)))?;
@@ -164,26 +172,22 @@ pub fn get_cpu_power_sensor(
 
     // Try platform-specific sensor first, fall back to TDP estimation
     #[cfg(target_os = "windows")]
-    if is_admin {
-        match WindowsCPUSensor::new(&vendor_id) {
-            Ok(sensor) => {
-                println!("✓ MSR sensor initialized successfully for vendor: {}", vendor_id);
-                return Ok(SensorType::CPU(CPUSensor {
-                    sensor: CPUOS::Windows(sensor),
-                    system: system.clone(),
-                }));
-            }
-            Err(e) => eprintln!("\u{26a0} MSR sensor unavailable ({:?}), falling back to estimation", e),
+    match WindowsCPUSensor::new(&vendor_id) {
+        Ok(sensor) => {
+            println!("✓ MSR sensor initialized successfully for vendor: {}", vendor_id);
+            return Ok(SensorType::CPU(CPUSensor {
+                sensor: CPUOS::WindowsRAPL(sensor),
+                system: system.clone(),
+            }));
         }
-    } else {
-        eprintln!("\u{26a0} Not running as Administrator, skipping MSR sensor (WinRing0 requires admin)");
+        Err(e) => eprintln!("\u{26a0} MSR sensor unavailable ({:?}), falling back to estimation", e),
     }
 
     #[cfg(target_os = "linux")]
     match LinuxCPUSensor::new() {
         Ok(sensor) => {
             return Ok(SensorType::CPU(CPUSensor {
-                sensor: CPUOS::Linux(sensor),
+                sensor: CPUOS::LinuxRAPL(sensor),
                 system: system.clone(),
             }));
         }

--- a/collector/src/sensors/cpu/windows_cpu/driver.rs
+++ b/collector/src/sensors/cpu/windows_cpu/driver.rs
@@ -1,72 +1,99 @@
-use std::{any::Any, ffi::c_ulong, panic, process::Command};
+use std::{thread, time::Duration};
 
-use common::clog;
-use win_ring0::WinRing0;
+use scaphandre_driver_rs::ScaphandreDriver;
 
-/// Safe wrapper around the WinRing0 kernel driver for MSR access.
-pub struct WinRing0Reader {
-    ring0: WinRing0,
+/// Safe wrapper around the Scaphandre RAPL driver for MSR access.
+pub struct ScaphandreMsrReader {
+    driver: ScaphandreDriver,
+    cpu_index: u32,
 }
 
-impl WinRing0Reader {
-    /// Installs and opens the WinRing0 driver, recovering from stuck state if needed.
+impl ScaphandreMsrReader {
+    fn has_windows_error_code(message: &str, code: u32) -> bool {
+        let code_fragment = format!("(code {code})");
+        message.contains(&code_fragment)
+    }
+
+    /// Opens the Scaphandre driver device for MSR access.
     pub fn new() -> Result<Self, String> {
-        clog!("Initializing WinRing0 driver...");
-        let mut handler = match panic::catch_unwind(|| WinRing0Reader { ring0: WinRing0::new() }) {
-            Ok(handler) => handler,
-            Err(e) => Self::free_stuck_driver(e)?,
-        };
-        clog!("Installing WinRing0 driver...");
-        handler.ring0.install().or_else(|_| handler.retry_install())?;
-        clog!("Opening WinRing0 driver...");
-        handler.ring0.open()?;
-        clog!("WinRing0 driver opened successfully.");
-        Ok(handler)
+        let driver = ScaphandreDriver::new().map_err(|e| format!("Failed to open Scaphandre driver: {e}"))?;
+        Ok(Self { driver, cpu_index: 0 })
     }
 
     /// Reads a Model-Specific Register by address.
-    pub fn read_msr(&self, msr: c_ulong) -> Result<u64, String> {
-        self.ring0.readMsr(msr)
+    pub fn read_msr(&self, msr: u32) -> Result<u64, String> {
+        self.driver
+            .read_msr(msr, self.cpu_index)
+            .map_err(|e| format!("Failed to read MSR {msr:#x}: {e}"))
     }
 
-    /// Uninstalls and re-installs the driver after a failed install.
-    fn retry_install(&mut self) -> Result<(), String> {
-        clog!("Uninstalling existing WinRing0 driver...");
-        self.ring0.uninstall()?;
-        clog!("Retrying WinRing0 driver installation...");
-        self.ring0.install()?;
-        Ok(())
-    }
-
-    /// Stops a stuck WinRing0 service and re-creates the reader.
-    fn free_stuck_driver(_: Box<dyn Any + Send>) -> Result<Self, String> {
-        clog!("WinRing0 initialization panicked. Freeing stuck driver...");
-        // sc stop WinRing0_1_2_0
-        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
-        let sc_path = format!(r"{}\System32\sc.exe", system_root);
-        Command::new(&sc_path).args(["stop", "WinRing0_1_2_0"]).output().ok();
-        clog!("Stuck WinRing0 driver stopped successfully.");
-        let mut handler = panic::catch_unwind(|| WinRing0Reader { ring0: WinRing0::new() })
-            .map_err(|e| format!("Failed to create WinRing0Reader after freeing driver: {:?}", e))?;
-        match handler.ring0.uninstall() {
-            Ok(_) => clog!("Stuck WinRing0 driver uninstalled successfully."),
-            Err(e) => clog!("Error uninstalling stuck WinRing0 driver: {}", e),
+    /// Returns whether the driver is installed on the system.
+    pub fn is_installed() -> bool {
+        match ScaphandreDriver::is_installed() {
+            Ok(installed) => installed,
+            Err(e) => {
+                eprintln!("Warning: failed to query Scaphandre driver status: {e}");
+                false
+            }
         }
-        return Ok(handler);
+    }
+
+    /// Installs the driver (requires Administrator privileges).
+    pub fn install() -> Result<(), String> {
+        let mut last_error = String::new();
+
+        // 1072 means the service is marked for deletion. This can be transient
+        // after uninstall or while another process still releases service handles.
+        for attempt in 0..3 {
+            match ScaphandreDriver::install() {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    let message = format!("{e}");
+                    if Self::has_windows_error_code(&message, 1072) && attempt < 2 {
+                        thread::sleep(Duration::from_millis(500));
+                        last_error = message;
+                        continue;
+                    }
+                    return Err(format!("Failed to install Scaphandre driver: {message}"));
+                }
+            }
+        }
+
+        Err(format!(
+            "Failed to install Scaphandre driver: {last_error}. Service is marked for deletion (code 1072); close apps using the driver and retry, or reboot Windows."
+        ))
+    }
+
+    /// Uninstalls the driver (requires Administrator privileges).
+    pub fn uninstall() -> Result<(), String> {
+        match ScaphandreDriver::is_installed() {
+            Ok(false) => return Ok(()),
+            Ok(true) => {}
+            Err(e) => return Err(format!("Failed to query Scaphandre driver status: {e}")),
+        }
+
+        let mut driver = match ScaphandreDriver::new() {
+            Ok(driver) => driver,
+            Err(e) => return Err(format!("Failed to open Scaphandre driver for uninstall: {e}")),
+        };
+
+        match driver.uninstall() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let message = format!("{e}");
+                if Self::has_windows_error_code(&message, 1072) {
+                    // Already marked for deletion: treat as successful uninstall.
+                    Ok(())
+                } else {
+                    Err(format!("Failed to uninstall Scaphandre driver: {message}"))
+                }
+            }
+        }
     }
 }
 
-impl Drop for WinRing0Reader {
+impl Drop for ScaphandreMsrReader {
     fn drop(&mut self) {
-        clog!("Closing WinRing0 driver...");
-        match self.ring0.close() {
-            Ok(_) => clog!("WinRing0 driver closed successfully."),
-            Err(e) => clog!("Error closing WinRing0 driver: {}", e),
-        }
-        clog!("Uninstalling WinRing0 driver...");
-        match self.ring0.uninstall() {
-            Ok(_) => clog!("WinRing0 driver uninstalled successfully."),
-            Err(e) => clog!("Error uninstalling WinRing0 driver: {}", e),
-        }
+        let _ = self.driver.close();
     }
 }

--- a/collector/src/sensors/cpu/windows_cpu/mod.rs
+++ b/collector/src/sensors/cpu/windows_cpu/mod.rs
@@ -1,11 +1,76 @@
 use std::{cell::RefCell, time::Instant};
 
-use driver::WinRing0Reader;
+use driver::ScaphandreMsrReader;
 
 use super::{CPUVendor, Sensor, SensorError};
 use crate::database::{CPUData, SensorData};
 
 mod driver;
+
+fn explain_driver_error(error: &str) -> String {
+    if error.contains("OpenSCManagerW (code 5)")
+        || error.contains("CreateServiceW (code 5)")
+        || error.contains("DeleteService (code 5)")
+        || error.contains("Access is denied")
+    {
+        return format!("{error}. Administrator privileges are required.");
+    }
+
+    if error.contains("(code 1072)") {
+        return format!(
+            "{error}. Windows reports the service is marked for deletion; close running WattSeal instances (and any tool using the Scaphandre driver), then retry. If it persists, reboot Windows."
+        );
+    }
+
+    error.to_string()
+}
+
+pub fn install() -> bool {
+    match ScaphandreMsrReader::install() {
+        Ok(()) => {
+            common::clog!("✓ CPU MSR driver installed successfully");
+            true
+        }
+        Err(e) => {
+            common::clog!("✗ Failed to install CPU MSR driver: {}", explain_driver_error(&e));
+            false
+        }
+    }
+}
+
+pub fn uninstall() -> bool {
+    match ScaphandreMsrReader::uninstall() {
+        Ok(()) => {
+            common::clog!("✓ CPU MSR driver uninstalled successfully");
+            true
+        }
+        Err(e) => {
+            common::clog!("✗ Failed to uninstall CPU MSR driver: {}", explain_driver_error(&e));
+            false
+        }
+    }
+}
+
+pub fn setup() {
+    if !ScaphandreMsrReader::is_installed() {
+        common::clog!("\u{26a0} CPU MSR driver not installed. Admin approval is required once to install it.");
+        if let Ok(exe) = std::env::current_exe() {
+            match runas::Command::new(&exe).arg("--install-cpu-driver").gui(true).status() {
+                Ok(status) if status.success() => {
+                    common::clog!("✓ CPU MSR driver installation completed");
+                }
+                Ok(_) => {
+                    common::clog!("\u{26a0} CPU MSR driver installation canceled or failed; using estimation");
+                }
+                Err(e) => {
+                    common::clog!("\u{26a0} Failed to launch driver installer: {e}");
+                }
+            }
+        } else {
+            common::clog!("\u{26a0} Unable to locate executable to install the CPU driver");
+        }
+    }
+}
 
 #[derive(Clone)]
 struct CPUValues {
@@ -46,19 +111,19 @@ impl Default for EnergyMeasurement {
     }
 }
 
-/// Windows CPU power sensor using MSR (Model-Specific Registers) via WinRing0.
+/// Windows CPU power sensor using MSR (Model-Specific Registers) via Scaphandre.
 pub struct WindowsCPUSensor {
     msr_reader: MSRReader,
     last_energy_measurement: RefCell<EnergyMeasurement>,
 }
 
 impl WindowsCPUSensor {
-    /// Initializes the WinRing0 driver and MSR reader for the given CPU vendor.
+    /// Initializes the Scaphandre driver and MSR reader for the given CPU vendor.
     pub fn new(vendor_id: &str) -> Result<Self, SensorError> {
         let vendor = CPUVendor::from_str(vendor_id);
-        let ring0_reader =
-            WinRing0Reader::new().map_err(|e| SensorError::ReadError(format!("WinRing0 init failed: {}", e)))?;
-        let msr_reader = MSRReader::new(ring0_reader, vendor);
+        let msr_driver = ScaphandreMsrReader::new()
+            .map_err(|e| SensorError::ReadError(format!("Scaphandre driver init failed: {}", e)))?;
+        let msr_reader = MSRReader::new(msr_driver, vendor);
 
         Ok(WindowsCPUSensor {
             msr_reader,
@@ -106,28 +171,28 @@ impl Sensor for WindowsCPUSensor {
 }
 
 struct MSRReader {
-    ring0_reader: WinRing0Reader,
+    msr_reader: ScaphandreMsrReader,
     vendor: CPUVendor,
     energy_unit: f64,
 }
 
 impl MSRReader {
-    fn new(ring0_reader: WinRing0Reader, vendor: CPUVendor) -> Self {
-        let energy_unit = Self::read_energy_unit(&ring0_reader, &vendor).unwrap_or(0.0);
+    fn new(msr_reader: ScaphandreMsrReader, vendor: CPUVendor) -> Self {
+        let energy_unit = Self::read_energy_unit(&msr_reader, &vendor).unwrap_or(0.0);
         MSRReader {
-            ring0_reader,
+            msr_reader,
             vendor,
             energy_unit,
         }
     }
 
-    fn read_energy_unit(ring0_reader: &WinRing0Reader, vendor: &CPUVendor) -> Result<f64, SensorError> {
+    fn read_energy_unit(msr_reader: &ScaphandreMsrReader, vendor: &CPUVendor) -> Result<f64, SensorError> {
         let read_fn = match vendor {
             CPUVendor::Intel => IntelMSR::read_energy_unit,
             CPUVendor::Amd => AMDMSR::read_energy_unit,
             CPUVendor::Other => return Err(SensorError::NotSupported),
         };
-        read_fn(ring0_reader).map_err(SensorError::ReadError)
+        read_fn(msr_reader).map_err(SensorError::ReadError)
     }
 
     fn read_energy(&self) -> Result<EnergyMeasurement, SensorError> {
@@ -136,7 +201,7 @@ impl MSRReader {
             CPUVendor::Amd => AMDMSR::read_energy_value,
             CPUVendor::Other => return Err(SensorError::NotSupported),
         };
-        let cpu_energy_values = read_fn(&self.ring0_reader).map_err(SensorError::ReadError)?;
+        let cpu_energy_values = read_fn(&self.msr_reader).map_err(SensorError::ReadError)?;
         Ok(EnergyMeasurement {
             cpu_energy_values,
             instant: Instant::now(),
@@ -205,18 +270,18 @@ trait MSR {
         ((edx as u64) << 32) | (eax as u64)
     }
     fn read_msr<T>(
-        ring0_reader: &WinRing0Reader,
+        msr_reader: &ScaphandreMsrReader,
         msr_addr: u32,
         expression: fn(edx: u32, eax: u32) -> T,
     ) -> Result<T, String> {
-        let out = ring0_reader.read_msr(msr_addr)?;
+        let out = msr_reader.read_msr(msr_addr)?;
         let edx = ((out >> 32) & 0xffffffff) as u32;
         let eax = (out & 0xffffffff) as u32;
         let result = expression(edx, eax);
         Ok(result)
     }
-    fn read_energy_unit(ring0_reader: &WinRing0Reader) -> Result<f64, String>;
-    fn read_energy_value(ring0_reader: &WinRing0Reader) -> Result<CPUValues, String>;
+    fn read_energy_unit(msr_reader: &ScaphandreMsrReader) -> Result<f64, String>;
+    fn read_energy_value(msr_reader: &ScaphandreMsrReader) -> Result<CPUValues, String>;
 }
 
 #[allow(non_camel_case_types)]
@@ -233,34 +298,18 @@ impl MSR for IntelMSR {
         let energy_unit_raw = (eax >> Self::ENERGY_UNIT_OFFSET) & Self::ENERGY_UNIT_MASK;
         1.0 / (1u64 << energy_unit_raw) as f64
     }
-    fn read_energy_unit(ring0_reader: &WinRing0Reader) -> Result<f64, String> {
+    fn read_energy_unit(msr_reader: &ScaphandreMsrReader) -> Result<f64, String> {
         Self::read_msr(
-            ring0_reader,
+            msr_reader,
             Self::MSR_RAPL_POWER_UNIT as u32,
             Self::energy_unit_expression,
         )
     }
-    fn read_energy_value(ring0_reader: &WinRing0Reader) -> Result<CPUValues, String> {
-        let pkg_energy = Self::read_msr(
-            ring0_reader,
-            Self::MSR_PKG_ENERGY_STATUS as u32,
-            Self::energy_expression,
-        )?;
-        let pp0_energy = Self::read_msr(
-            ring0_reader,
-            Self::MSR_PP0_ENERGY_STATUS as u32,
-            Self::energy_expression,
-        )?;
-        let pp1_energy = Self::read_msr(
-            ring0_reader,
-            Self::MSR_PP1_ENERGY_STATUS as u32,
-            Self::energy_expression,
-        )?;
-        let dram_energy = Self::read_msr(
-            ring0_reader,
-            Self::MSR_DRAM_ENERGY_STATUS as u32,
-            Self::energy_expression,
-        )?;
+    fn read_energy_value(msr_reader: &ScaphandreMsrReader) -> Result<CPUValues, String> {
+        let pkg_energy = Self::read_msr(msr_reader, Self::MSR_PKG_ENERGY_STATUS as u32, Self::energy_expression)?;
+        let pp0_energy = Self::read_msr(msr_reader, Self::MSR_PP0_ENERGY_STATUS as u32, Self::energy_expression)?;
+        let pp1_energy = Self::read_msr(msr_reader, Self::MSR_PP1_ENERGY_STATUS as u32, Self::energy_expression)?;
+        let dram_energy = Self::read_msr(msr_reader, Self::MSR_DRAM_ENERGY_STATUS as u32, Self::energy_expression)?;
 
         Ok(CPUValues {
             pkg: Some(pkg_energy as f64),
@@ -284,17 +333,17 @@ impl MSR for AMDMSR {
         1.0 / (1u64 << energy_unit_raw) as f64
     }
 
-    fn read_energy_unit(ring0_reader: &WinRing0Reader) -> Result<f64, String> {
+    fn read_energy_unit(msr_reader: &ScaphandreMsrReader) -> Result<f64, String> {
         Self::read_msr(
-            ring0_reader,
+            msr_reader,
             Self::ENERGY_PWR_UNIT_MSR as u32,
             Self::energy_unit_expression,
         )
     }
 
-    fn read_energy_value(ring0_reader: &WinRing0Reader) -> Result<CPUValues, String> {
-        let pkg_energy: u64 = Self::read_msr(ring0_reader, Self::ENERGY_PKG_MSR as u32, Self::energy_expression)?;
-        let pp0_energy = Self::read_msr(ring0_reader, Self::ENERGY_CORE_MSR as u32, Self::energy_expression)?;
+    fn read_energy_value(msr_reader: &ScaphandreMsrReader) -> Result<CPUValues, String> {
+        let pkg_energy: u64 = Self::read_msr(msr_reader, Self::ENERGY_PKG_MSR as u32, Self::energy_expression)?;
+        let pp0_energy = Self::read_msr(msr_reader, Self::ENERGY_CORE_MSR as u32, Self::energy_expression)?;
 
         Ok(CPUValues {
             pkg: Some(pkg_energy as f64),

--- a/collector/src/sensors/mod.rs
+++ b/collector/src/sensors/mod.rs
@@ -168,7 +168,7 @@ pub fn create_event_from_sensors(sensors: &Vec<SensorType>, system: Rc<RefCell<S
     }
 
     // --- Integrated-GPU power resolution ---
-    // Priority 1: Real PP1 reading from MSR (WinRing0).
+    // Priority 1: Real PP1 reading from MSR (Scaphandre driver).
     if let Some(igpu_power) = integrated_gpu_power {
         let merged = data.iter_mut().any(|d| {
             if let SensorData::GPU(gpu) = d {

--- a/resources/linux/WattSeal.desktop
+++ b/resources/linux/WattSeal.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=WattSeal
+Comment=Real-time PC power consumption monitoring
+Exec=WattSeal
+Icon=WattSeal
+Terminal=false
+Categories=Utility;System;Monitor;
+Keywords=power;energy;monitoring;hardware;
+StartupNotify=true

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,10 @@ struct Options {
     mqtt_id: Option<String>,
     mqtt_addr: Option<SocketAddr>,
     db_mode: bool,
+    #[cfg(target_os = "windows")]
+    install_cpu_driver: bool,
+    #[cfg(target_os = "windows")]
+    uninstall_cpu_driver: bool,
 }
 
 /// Returns options parser to run
@@ -67,16 +71,45 @@ fn options() -> OptionParser<Options> {
         .help("Do not save sensors metrics in local database.")
         .flag(false, true);
 
-    construct!(Options {
-        ui_mode,
-        background_mode,
-        headless_mode,
-        mqtt_id,
-        mqtt_addr,
-        db_mode,
-    })
-    .to_options()
-    .descr("WattSeal - Per-app power monitoring tool")
+    let description = "WattSeal - Per-app power monitoring tool";
+
+    #[cfg(target_os = "windows")]
+    {
+        let install_cpu_driver = long("install-cpu-driver")
+            .help("Install the Windows CPU MSR driver (requires Administrator privileges).")
+            .switch();
+
+        let uninstall_cpu_driver = long("uninstall-cpu-driver")
+            .help("Uninstall the Windows CPU MSR driver (requires Administrator privileges).")
+            .switch();
+
+        return construct!(Options {
+            ui_mode,
+            background_mode,
+            headless_mode,
+            mqtt_id,
+            mqtt_addr,
+            db_mode,
+            install_cpu_driver,
+            uninstall_cpu_driver,
+        })
+        .to_options()
+        .descr(description);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        return construct!(Options {
+            ui_mode,
+            background_mode,
+            headless_mode,
+            mqtt_id,
+            mqtt_addr,
+            db_mode,
+        })
+        .to_options()
+        .descr(description);
+    }
 }
 
 /// Spawns the UI subprocess if not already running.
@@ -211,16 +244,18 @@ fn main() {
     let options = options().run();
 
     #[cfg(target_os = "windows")]
-    if !options.ui_mode && !is_admin::is_admin() {
-        let exe = std::env::current_exe();
-        if let Ok(exe) = exe {
-            let args: Vec<String> = std::env::args().skip(1).collect();
-            let relaunched = runas::Command::new(&exe).args(&args).gui(true).status();
-            match relaunched {
-                Ok(status) if status.success() => return,
-                _ => {}
-            }
+    {
+        if options.install_cpu_driver {
+            collector::sensors::cpu::windows_cpu::install();
+            return;
         }
+
+        if options.uninstall_cpu_driver {
+            collector::sensors::cpu::windows_cpu::uninstall();
+            return;
+        }
+
+        collector::sensors::cpu::windows_cpu::setup();
     }
 
     if !options.db_mode && options.mqtt_addr.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,10 @@ fn main() {
             return;
         }
 
-        collector::sensors::cpu::windows_cpu::setup();
+        // Prevent UI process from trying to setup the driver again
+        if !options.ui_mode {
+            collector::sensors::cpu::windows_cpu::setup();
+        }
     }
 
     if !options.db_mode && options.mqtt_addr.is_none() {


### PR DESCRIPTION
## Description

Replaces Winring0 driver on Windows with the better scoped Scaphandre driver via the [scaphandre-driver-rs](https://crates.io/crates/scaphandre-driver-rs) crate.

## Related issue

Closes #19 

## Changes

> Windows only
- Replaces Winring0 with Scaphandre driver (only read access to MSR)
- Admin access only needed once to install instead of all the time to have best precision
- 2 new options: `--install-cpu-driver` and `--uninstall-cpu-driver` only to install or uninstall the driver (admin rights needed, no automatic elevation request)
- For normal use, if the driver is not installed, a subprocess with auto admin elevation request is created only for installation

## Checklist

- [x] `cargo build` passes
- [x] `cargo +nightly fmt` applied
- [x] Changes are scoped to the described issue
