### PR TITLE
Split sensors and computed sensors

### DIFF
--- a/collector/src/database/mod.rs
+++ b/collector/src/database/mod.rs
@@ -2,5 +2,8 @@ mod tables;
 
 pub use common::{
     DATABASE_PATH, Database, DatabaseEntry, Event,
-    types::{Byte, CPUData, DiskData, EnergyUj, GPUData, NetworkData, ProcessData, RamData, SensorData, TotalData},
+    types::{
+        Byte, CPUData, ComputedSensorData, DiskData, EnergyUj, GPUData, NetworkData, ProcessData, RamData, SensorData,
+        TotalData,
+    },
 };

--- a/collector/src/database/tables.rs
+++ b/collector/src/database/tables.rs
@@ -1,6 +1,6 @@
-use common::{DatabaseEntry, ProcessData};
+use common::DatabaseEntry;
 
-use super::{CPUData, DiskData, GPUData, NetworkData, RamData, TotalData};
+use super::{CPUData, DiskData, GPUData, NetworkData, RamData};
 use crate::sensors::SensorType;
 
 impl SensorType {
@@ -12,8 +12,6 @@ impl SensorType {
             SensorType::RAM(_) => RamData::table_name_static(),
             SensorType::Disk(_) => DiskData::table_name_static(),
             SensorType::Network(_) => NetworkData::table_name_static(),
-            SensorType::Total => TotalData::table_name_static(),
-            SensorType::Process => ProcessData::table_name_static(),
         }
     }
 }

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -13,12 +13,12 @@ pub use common::clog;
 #[cfg(not(debug_assertions))]
 use common::logging::start_log_session;
 use common::{
-    DatabaseEntry, ProcessData, SensorData, TotalData, database::purge::averaging_and_purging_data, types::EnergyWh,
+    DatabaseEntry, ProcessData, TotalData, database::purge::averaging_and_purging_data, types::PublishableSensor,
 };
 use database::Database;
 use mqtt::{
     MQTTPublisher,
-    topics::{hardware_info_topic, sensor_data_to_topic},
+    topics::{hardware_info_topic, sensor_type_to_topic},
 };
 use sensors::{
     DiskSensor, NetworkSensor, RamSensor, SensorType, create_event_from_sensors, get_hardware_info,
@@ -36,11 +36,19 @@ pub enum ConsumptionUnit {
     UJoul,
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+pub enum MqttDataMode {
+    #[default]
+    Computed,
+    Raw,
+}
+
 /// MQTT information to interact with a MQTT client
 pub struct MQTTInfo {
     id: String,
     publisher: MQTTPublisher<rumqttc::Client>,
     unit: Option<ConsumptionUnit>,
+    data_mode: MqttDataMode,
 }
 
 /// Background sensor-collection application.
@@ -56,12 +64,13 @@ pub struct CollectorApp {
 }
 
 impl MQTTInfo {
-    pub fn new(id: &str, addr: &SocketAddr, unit: Option<ConsumptionUnit>) -> Self {
+    pub fn new(id: &str, addr: &SocketAddr, unit: Option<ConsumptionUnit>, is_raw_mode: bool) -> Self {
         let publisher = MQTTPublisher::new_from_addr(addr);
         MQTTInfo {
             id: id.to_string(),
             publisher,
             unit,
+            data_mode: is_raw_mode.then_some(MqttDataMode::Raw).unwrap_or_default(),
         }
     }
 }
@@ -173,12 +182,14 @@ impl CollectorApp {
         self.sensors.push(SensorType::RAM(RamSensor::new(self.system.clone())));
         self.sensors.push(SensorType::Disk(DiskSensor::new()));
         self.sensors.push(SensorType::Network(NetworkSensor::new()));
+
+        let mut table_names: Vec<String> = self.sensors.iter().map(|s| s.table_name().into()).collect();
+        table_names.push(ProcessData::table_name_static().into());
+        table_names.push(TotalData::table_name_static().into());
+
         if let Some(database) = &mut self.database {
             // Database
             crate::clog!("\n========== SETTING UP DATABASE ==========");
-            let mut table_names: Vec<&str> = self.sensors.iter().map(|s| s.table_name()).collect();
-            table_names.push(ProcessData::table_name_static());
-            table_names.push(TotalData::table_name_static());
             database
                 .create_tables_if_not_exists(&table_names)
                 .map_err(|e| format!("Failed to create database tables: {e}"))?;
@@ -187,7 +198,7 @@ impl CollectorApp {
 
         // Hardware info
         crate::clog!("\n========== GATHERING HARDWARE INFORMATION ==========\n");
-        let info = get_hardware_info(&self.sensors);
+        let info = get_hardware_info(&self.sensors, &table_names);
 
         if let Some(database) = &mut self.database {
             match database.insert_hardware_info(&info) {
@@ -197,7 +208,7 @@ impl CollectorApp {
         }
         if let Some(mqtt_info) = &self.mqtt_info {
             let topic = hardware_info_topic(&mqtt_info.id);
-            match mqtt_info.publisher.publish(&topic, &info.hardware_info_serialized) {
+            match mqtt_info.publisher.publish(&topic, &info.hardware_info) {
                 Ok(_) => crate::clog!("✓ Hardware info published on broker"),
                 Err(e) => crate::clog!("✗ Failed to publish hardware info: {e}"),
             }
@@ -229,48 +240,53 @@ impl CollectorApp {
 
             let event = create_event_from_sensors(&self.sensors, since_last_update);
 
-            if let Some(database) = &mut self.database {
+            let needs_computed = self.database.is_some()
+                || self
+                    .mqtt_info
+                    .as_ref()
+                    .is_some_and(|m| m.data_mode == MqttDataMode::Computed);
+
+            let computed_event = needs_computed.then(|| {
                 let process_gpu_usage = sensors::get_process_gpu_usage(&self.sensors);
-                let computed_event = to_computed_event(&event, self.system.clone(), process_gpu_usage);
-                println!("Computed Event: {:#?}", computed_event);
-                #[cfg(debug_assertions)]
-                {
-                    let start = Instant::now();
+                to_computed_event(&event, self.system.clone(), process_gpu_usage)
+            });
 
-                    let result = database.insert_event_and_update_energy(&computed_event, 1);
-                    let duration = start.elapsed();
+            if let Some(database) = &mut self.database {
+                if let Some(computed_event) = &computed_event {
+                    #[cfg(debug_assertions)]
+                    {
+                        let start = Instant::now();
 
-                    for sensor_data in computed_event.data() {
-                        println!("{sensor_data}");
+                        let result = database.insert_event_and_update_energy(&computed_event, 1);
+                        let duration = start.elapsed();
+
+                        for sensor_data in computed_event.data() {
+                            println!("{sensor_data}");
+                        }
+                        match result {
+                            Ok(_) => println!("✓ Event data saved to database (took {:.2?})", duration),
+                            Err(e) => eprintln!("✗ Failed to save event data: {:?}", e),
+                        }
                     }
-                    match result {
-                        Ok(_) => println!("✓ Event data saved to database (took {:.2?})", duration),
-                        Err(e) => eprintln!("✗ Failed to save event data: {:?}", e),
-                    }
+
+                    #[cfg(not(debug_assertions))]
+                    let _ = database.insert_event_and_update_energy(&computed_event, 1);
                 }
-
-                #[cfg(not(debug_assertions))]
-                let _ = database.insert_event_and_update_energy(&computed_event, 1);
             }
 
             if let Some(mqtt_info) = &self.mqtt_info {
-                for sensor_data in event.data() {
-                    let topic = sensor_data_to_topic(&mqtt_info.id, &sensor_data);
-
-                    let _result = mqtt_info.unit.map_or_else(
-                        || mqtt_info.publisher.publish(&topic, sensor_data),
-                        |u| match u {
-                            ConsumptionUnit::UJoul => mqtt_info.publisher.publish(&topic, &sensor_data),
-                            ConsumptionUnit::WattHour => {
-                                let sensor_data_wh: SensorData<EnergyWh> = sensor_data.to_wh();
-                                mqtt_info.publisher.publish(&topic, &sensor_data_wh)
+                match mqtt_info.data_mode {
+                    MqttDataMode::Raw => {
+                        for sensor_data in event.data() {
+                            publish_sensor(mqtt_info, sensor_data);
+                        }
+                    }
+                    MqttDataMode::Computed => {
+                        if let Some(computed) = &computed_event {
+                            for sensor_data in computed.data() {
+                                publish_sensor(mqtt_info, sensor_data);
                             }
-                        },
-                    );
-                    #[cfg(debug_assertions)]
-                    match _result {
-                        Ok(_) => println!("✓ Sensor data published on topic {}", topic),
-                        Err(e) => eprintln!("✗ Failed to publish sensor data on topic {}: {:?}", topic, e),
+                        }
                     }
                 }
             }
@@ -298,5 +314,18 @@ impl CollectorApp {
                 thread::sleep(Duration::from_millis(1000 - now_sub_ms as u64));
             }
         }
+    }
+}
+
+fn publish_sensor<T: PublishableSensor>(mqtt_info: &MQTTInfo, sensor_data: &T) {
+    let topic = sensor_type_to_topic(&mqtt_info.id, sensor_data.sensor_type());
+    let _result = match mqtt_info.unit {
+        Some(ConsumptionUnit::WattHour) => mqtt_info.publisher.publish(&topic, &sensor_data.to_wh()),
+        _ => mqtt_info.publisher.publish(&topic, sensor_data),
+    };
+    #[cfg(debug_assertions)]
+    match _result {
+        Ok(_) => println!("✓ Sensor data published on topic {}", topic),
+        Err(e) => eprintln!("✗ Failed to publish sensor data on topic {}: {:?}", topic, e),
     }
 }

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -12,7 +12,9 @@ use std::{
 pub use common::clog;
 #[cfg(not(debug_assertions))]
 use common::logging::start_log_session;
-use common::{SensorData, database::purge::averaging_and_purging_data, types::EnergyWh};
+use common::{
+    DatabaseEntry, ProcessData, SensorData, TotalData, database::purge::averaging_and_purging_data, types::EnergyWh,
+};
 use database::Database;
 use mqtt::{
     MQTTPublisher,
@@ -23,6 +25,8 @@ use sensors::{
     gpu::{GPUVendor, get_gpu_list},
 };
 use sysinfo::System;
+
+use crate::sensors::to_computed_event;
 
 /// Possible units to choose as output
 #[derive(Debug, Default, Clone, Copy)]
@@ -169,13 +173,12 @@ impl CollectorApp {
         self.sensors.push(SensorType::RAM(RamSensor::new(self.system.clone())));
         self.sensors.push(SensorType::Disk(DiskSensor::new()));
         self.sensors.push(SensorType::Network(NetworkSensor::new()));
-        self.sensors.push(SensorType::Total);
-        self.sensors.push(SensorType::Process);
-
         if let Some(database) = &mut self.database {
             // Database
             crate::clog!("\n========== SETTING UP DATABASE ==========");
-            let table_names: Vec<&str> = self.sensors.iter().map(|s| s.table_name()).collect();
+            let mut table_names: Vec<&str> = self.sensors.iter().map(|s| s.table_name()).collect();
+            table_names.push(ProcessData::table_name_static());
+            table_names.push(TotalData::table_name_static());
             database
                 .create_tables_if_not_exists(&table_names)
                 .map_err(|e| format!("Failed to create database tables: {e}"))?;
@@ -224,14 +227,22 @@ impl CollectorApp {
             #[cfg(debug_assertions)]
             println!("\n--- Iteration {} ---", self.iteration);
 
-            let event = create_event_from_sensors(&self.sensors, self.system.clone(), since_last_update);
+            let event = create_event_from_sensors(&self.sensors, since_last_update);
 
             if let Some(database) = &mut self.database {
+                let process_gpu_usage = sensors::get_process_gpu_usage(&self.sensors);
+                let computed_event = to_computed_event(&event, self.system.clone(), process_gpu_usage);
+                println!("Computed Event: {:#?}", computed_event);
                 #[cfg(debug_assertions)]
                 {
                     let start = Instant::now();
-                    let result = database.insert_event_and_update_energy(&event, 1);
+
+                    let result = database.insert_event_and_update_energy(&computed_event, 1);
                     let duration = start.elapsed();
+
+                    for sensor_data in computed_event.data() {
+                        println!("{sensor_data}");
+                    }
                     match result {
                         Ok(_) => println!("✓ Event data saved to database (took {:.2?})", duration),
                         Err(e) => eprintln!("✗ Failed to save event data: {:?}", e),
@@ -239,7 +250,7 @@ impl CollectorApp {
                 }
 
                 #[cfg(not(debug_assertions))]
-                let _ = database.insert_event_and_update_energy(&event, 1);
+                let _ = database.insert_event_and_update_energy(&computed_event, 1);
             }
 
             if let Some(mqtt_info) = &self.mqtt_info {

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -238,7 +238,7 @@ impl CollectorApp {
             #[cfg(debug_assertions)]
             println!("\n--- Iteration {} ---", self.iteration);
 
-            let event = create_event_from_sensors(&self.sensors, since_last_update);
+            let event = create_event_from_sensors(&self.sensors, self.system.clone(), since_last_update);
 
             let needs_computed = self.database.is_some()
                 || self
@@ -246,10 +246,7 @@ impl CollectorApp {
                     .as_ref()
                     .is_some_and(|m| m.data_mode == MqttDataMode::Computed);
 
-            let computed_event = needs_computed.then(|| {
-                let process_gpu_usage = sensors::get_process_gpu_usage(&self.sensors);
-                to_computed_event(&event, self.system.clone(), process_gpu_usage)
-            });
+            let computed_event = needs_computed.then(|| to_computed_event(&event));
 
             if let Some(database) = &mut self.database {
                 if let Some(computed_event) = &computed_event {
@@ -292,8 +289,16 @@ impl CollectorApp {
             }
 
             #[cfg(debug_assertions)]
-            for sensor_data in event.data() {
-                println!("{sensor_data}");
+            {
+                if let Some(computed) = &computed_event {
+                    for sensor_data in computed.data() {
+                        println!("{sensor_data}");
+                    }
+                } else {
+                    for sensor_data in event.data() {
+                        println!("{sensor_data}");
+                    }
+                }
             }
 
             #[cfg(debug_assertions)]

--- a/collector/src/sensors/mod.rs
+++ b/collector/src/sensors/mod.rs
@@ -23,9 +23,10 @@ pub use disk::DiskSensor;
 use display_info::DisplayInfo;
 pub use gpu::{GPUSensor, get_gpu_list};
 pub use network::NetworkSensor;
-pub use process::get_processes;
 pub use ram::RamSensor;
 use sysinfo::System;
+
+use crate::sensors::process::{compute_processes_energy, get_measured_processes, sort_processes_by_energy};
 
 /// Variant wrapper for all supported sensor types.
 pub enum SensorType {
@@ -88,7 +89,11 @@ pub enum SensorError {
 }
 
 /// Aggregates readings from all sensors into a single timestamped event.
-pub fn create_event_from_sensors(sensors: &Vec<SensorType>, since_last_update: Duration) -> Event {
+pub fn create_event_from_sensors(
+    sensors: &Vec<SensorType>,
+    system: Rc<RefCell<System>>,
+    since_last_update: Duration,
+) -> Event {
     let time = SystemTime::now();
     let mut data: Vec<SensorData> = Vec::new();
 
@@ -165,16 +170,14 @@ pub fn create_event_from_sensors(sensors: &Vec<SensorType>, since_last_update: D
         }
     }
 
-    // TODO: Measure processes + process gpu usage
+    let proc_gpu_usage = get_process_gpu_usage(sensors);
+    let measured_processes = get_measured_processes(system, proc_gpu_usage);
+    data.push(SensorData::Process(measured_processes));
 
     return Event::new(time, data);
 }
 
-pub fn to_computed_event(
-    sensors_event: &Event,
-    system: Rc<RefCell<System>>,
-    process_gpu_usage: HashMap<u32, f64>,
-) -> Event<ComputedSensorData> {
+pub fn to_computed_event(sensors_event: &Event) -> Event<ComputedSensorData> {
     let mut data: Vec<ComputedSensorData> = Vec::new();
     let (mut cpu_energy, mut cpu_usage, mut nb_cpus) = (EnergyUj::from_u64(0), 0.0, 0);
     let (mut gpu_energy, mut gpu_usage, mut nb_gpus) = (EnergyUj::from_u64(0), 0.0, 0);
@@ -204,17 +207,30 @@ pub fn to_computed_event(
 
     cpu_usage /= nb_cpus.max(1) as f64;
     gpu_usage /= nb_gpus.max(1) as f64;
-    let top10_process_data: Vec<ProcessData> = get_processes(
-        system.clone(),
+    let computed_process_data = compute_processes_energy(
+        sensors_event
+            .data()
+            .iter()
+            .filter_map(|d| {
+                if let SensorData::Process(measured_processes) = d {
+                    Some(measured_processes.to_vec())
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect(),
         cpu_energy,
         cpu_usage,
         gpu_energy,
         gpu_usage,
         total_energy,
-        10,
-        process_gpu_usage,
     );
-    data.push(ComputedSensorData::Process(top10_process_data));
+    let top10_processes: Vec<ProcessData> = sort_processes_by_energy(computed_process_data)
+        .into_iter()
+        .take(10)
+        .collect();
+    data.push(ComputedSensorData::Process(top10_processes));
 
     Event::new(sensors_event.time(), data)
 }

--- a/collector/src/sensors/mod.rs
+++ b/collector/src/sensors/mod.rs
@@ -242,14 +242,11 @@ pub fn get_process_gpu_usage(sensors: &Vec<SensorType>) -> HashMap<u32, f64> {
 }
 
 /// Collects hardware info (names + initial specs) from all sensors.
-pub fn get_hardware_info(sensors: &Vec<SensorType>) -> GeneralData {
-    let mut tables: Vec<String> = Vec::new();
+pub fn get_hardware_info(sensors: &Vec<SensorType>, table_names: &Vec<String>) -> GeneralData {
     let mut detected_materials: Vec<String> = Vec::new();
     let mut sensors_info: Vec<InitialInfo> = Vec::new();
 
     for sensor in sensors {
-        tables.push(sensor.table_name().to_string());
-
         match sensor.read_name() {
             Ok(name) => detected_materials.push(name),
             Err(SensorError::NotSupported) => {}
@@ -339,8 +336,8 @@ pub fn get_hardware_info(sensors: &Vec<SensorType>) -> GeneralData {
     let hardware_info: HardwareInfo = sensors_info.into();
 
     let data = GeneralData {
-        tables: tables.join(","),
-        hardware_info_serialized: hardware_info.serialized(),
+        tables: table_names.join(","),
+        hardware_info: hardware_info,
     };
 
     return data;

--- a/collector/src/sensors/mod.rs
+++ b/collector/src/sensors/mod.rs
@@ -15,7 +15,7 @@ use std::{
 use battery::Manager;
 use common::types::EnergyUj;
 pub use common::{
-    AllTimeData, Event, GPUData, GeneralData, ProcessData, SensorData, TotalData,
+    AllTimeData, ComputedSensorData, Event, GPUData, GeneralData, ProcessData, SensorData, TotalData,
     types::{BatteryInfo, CpuInfo, DiskInfo, HardwareInfo, InitialInfo, MemoryInfo, ScreenInfo, SystemInfo},
 };
 pub use cpu::CPUSensor;
@@ -34,8 +34,6 @@ pub enum SensorType {
     RAM(RamSensor),
     Disk(DiskSensor),
     Network(NetworkSensor),
-    Process,
-    Total,
 }
 
 impl Sensor for SensorType {
@@ -46,8 +44,6 @@ impl Sensor for SensorType {
             SensorType::RAM(sensor) => sensor.read_full_data(),
             SensorType::Disk(sensor) => sensor.read_full_data(),
             SensorType::Network(sensor) => sensor.read_full_data(),
-            SensorType::Process => Err(SensorError::NotSupported),
-            SensorType::Total => Err(SensorError::NotSupported),
         }
     }
 
@@ -58,8 +54,6 @@ impl Sensor for SensorType {
             SensorType::RAM(sensor) => sensor.read_initial_info(),
             SensorType::Disk(sensor) => sensor.read_initial_info(),
             SensorType::Network(_) => Err(SensorError::NotSupported),
-            SensorType::Process => Err(SensorError::NotSupported),
-            SensorType::Total => Err(SensorError::NotSupported),
         }
     }
 
@@ -70,8 +64,6 @@ impl Sensor for SensorType {
             SensorType::Disk(sensor) => sensor.read_name(),
             SensorType::Network(sensor) => sensor.read_name(),
             SensorType::RAM(_) => Err(SensorError::NotSupported),
-            SensorType::Process => Err(SensorError::NotSupported),
-            SensorType::Total => Err(SensorError::NotSupported),
         }
     }
 }
@@ -96,40 +88,14 @@ pub enum SensorError {
 }
 
 /// Aggregates readings from all sensors into a single timestamped event.
-pub fn create_event_from_sensors(
-    sensors: &Vec<SensorType>,
-    system: Rc<RefCell<System>>,
-    since_last_update: Duration,
-) -> Event {
+pub fn create_event_from_sensors(sensors: &Vec<SensorType>, since_last_update: Duration) -> Event {
     let time = SystemTime::now();
     let mut data: Vec<SensorData> = Vec::new();
 
-    let (mut cpu_energy, mut cpu_usage, mut nb_cpus) = (EnergyUj::from_u64(0), 0.0, 0);
-    let (mut gpu_energy, mut gpu_usage, mut nb_gpus) = (EnergyUj::from_u64(0), 0.0, 0);
-
-    let mut total_energy = EnergyUj::from_u64(0);
     let mut integrated_gpu_energy: Option<EnergyUj> = None;
     let mut has_pp1_source = false;
     let mut integrated_gpu_indices: Vec<usize> = Vec::new();
-    let mut proc_gpu_usage = HashMap::new();
     for sensor in sensors {
-        match sensor {
-            SensorType::Process | SensorType::Total => continue,
-            SensorType::GPU(gpu_sensor) => {
-                if let Ok(gpu_process_usage) = gpu_sensor.get_process_gpu_usage(
-                    time.duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs(),
-                ) {
-                    proc_gpu_usage.extend(gpu_process_usage);
-                }
-            }
-            _ => {}
-        }
-        if let SensorType::Total | SensorType::Process = sensor {
-            continue;
-        }
-
         let sensor_data = sensor.read_full_data();
         match sensor_data {
             Ok(mut d) => {
@@ -142,22 +108,6 @@ pub fn create_event_from_sensors(
                             }
                             integrated_gpu_energy = Some(pp1);
                         }
-                    }
-                }
-
-                if let Some(energy) = d.total_energy() {
-                    total_energy += energy;
-
-                    if let SensorData::CPU(cpu) = &d {
-                        cpu_energy += energy;
-                        cpu_usage += cpu.usage_percent.unwrap_or(0.0);
-                        nb_cpus += 1;
-                    }
-
-                    if let SensorData::GPU(gpu) = &d {
-                        gpu_energy += energy;
-                        gpu_usage += gpu.usage_percent.unwrap_or(0.0);
-                        nb_gpus += 1;
                     }
                 }
 
@@ -198,10 +148,7 @@ pub fn create_event_from_sensors(
                 usage_percent: None,
                 vram_usage_percent: None,
             }));
-            nb_gpus += 1;
         }
-        gpu_energy += igpu_energy;
-        total_energy += igpu_energy;
     }
 
     // Priority 2: Estimate iGPU energy from usage when PP1 is unavailable.
@@ -212,18 +159,51 @@ pub fn create_event_from_sensors(
                     if let Some(usage) = gpu.usage_percent {
                         let estimated = cpu::estimate_igpu_energy(usage, since_last_update);
                         gpu.total_energy = Some(estimated);
-                        gpu_energy += estimated;
                     }
                 }
             }
         }
     }
 
-    data.push(SensorData::Total(TotalData { total_energy }));
+    // TODO: Measure processes + process gpu usage
+
+    return Event::new(time, data);
+}
+
+pub fn to_computed_event(
+    sensors_event: &Event,
+    system: Rc<RefCell<System>>,
+    process_gpu_usage: HashMap<u32, f64>,
+) -> Event<ComputedSensorData> {
+    let mut data: Vec<ComputedSensorData> = Vec::new();
+    let (mut cpu_energy, mut cpu_usage, mut nb_cpus) = (EnergyUj::from_u64(0), 0.0, 0);
+    let (mut gpu_energy, mut gpu_usage, mut nb_gpus) = (EnergyUj::from_u64(0), 0.0, 0);
+
+    let mut total_energy = EnergyUj::from_u64(0);
+
+    for sensor_data in sensors_event.data().iter() {
+        if let Some(energy) = sensor_data.total_energy() {
+            total_energy += energy;
+
+            if let SensorData::CPU(cpu) = &sensor_data {
+                cpu_energy += energy;
+                cpu_usage += cpu.usage_percent.unwrap_or(0.0);
+                nb_cpus += 1;
+            }
+
+            if let SensorData::GPU(gpu) = &sensor_data {
+                gpu_energy += energy;
+                gpu_usage += gpu.usage_percent.unwrap_or(0.0);
+                nb_gpus += 1;
+            }
+        }
+        data.push(sensor_data.clone().into());
+    }
+
+    data.push(ComputedSensorData::Total(TotalData { total_energy }));
 
     cpu_usage /= nb_cpus.max(1) as f64;
     gpu_usage /= nb_gpus.max(1) as f64;
-
     let top10_process_data: Vec<ProcessData> = get_processes(
         system.clone(),
         cpu_energy,
@@ -232,11 +212,33 @@ pub fn create_event_from_sensors(
         gpu_usage,
         total_energy,
         10,
-        proc_gpu_usage,
+        process_gpu_usage,
     );
-    data.push(SensorData::Process(top10_process_data));
+    data.push(ComputedSensorData::Process(top10_process_data));
 
-    return Event::new(time, data);
+    Event::new(sensors_event.time(), data)
+}
+
+pub fn get_process_gpu_usage(sensors: &Vec<SensorType>) -> HashMap<u32, f64> {
+    let time = SystemTime::now();
+    let mut proc_gpu_usage = HashMap::new();
+
+    for sensor in sensors {
+        match sensor {
+            SensorType::GPU(gpu_sensor) => {
+                if let Ok(gpu_process_usage) = gpu_sensor.get_process_gpu_usage(
+                    time.duration_since(SystemTime::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs(),
+                ) {
+                    proc_gpu_usage.extend(gpu_process_usage);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    proc_gpu_usage
 }
 
 /// Collects hardware info (names + initial specs) from all sensors.

--- a/collector/src/sensors/process.rs
+++ b/collector/src/sensors/process.rs
@@ -1,25 +1,19 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
-use common::types::EnergyUj;
-use sysinfo::{Pid, Process, System};
+use common::types::{Byte, EnergyUj, MeasuredProcessData};
+use sysinfo::System;
 
 use crate::sensors::ProcessData;
 
-/// Collects the top-N processes ranked by estimated energy consumption.
-pub fn get_processes(
+/// Collects the measured processes data without estimating energy consumption.
+pub fn get_measured_processes(
     system: Rc<RefCell<System>>,
-    cpu_energy: EnergyUj,
-    cpu_usage: f64,
-    gpu_energy: EnergyUj,
-    gpu_usage: f64,
-    total_energy: EnergyUj,
-    number_processes: usize,
     proc_gpu_usage: HashMap<u32, f64>,
-) -> Vec<ProcessData> {
+) -> Vec<MeasuredProcessData> {
     let mut sys = match system.try_borrow_mut() {
         Ok(sys) => sys,
         Err(e) => {
-            crate::clog!("✗ Failed to borrow system for process collection: {}", e);
+            crate::clog!("✗ Failed to borrow system for measured process collection: {}", e);
             return Vec::new();
         }
     };
@@ -35,38 +29,40 @@ pub fn get_processes(
             .without_user(),
     );
 
-    let mut processes = extract_and_group_processes(
-        sys.processes(),
-        sys.total_memory(),
-        cpu_energy,
-        cpu_usage,
-        nb_cores,
-        gpu_energy,
-        gpu_usage,
-        total_energy,
-        proc_gpu_usage,
-    );
+    let mut measured_processes: Vec<MeasuredProcessData> = Vec::new();
+    let processes = sys.processes();
+    let total_memory = sys.total_memory();
 
-    processes.sort_by(|a, b| {
-        b.process_energy
-            .partial_cmp(&a.process_energy)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    for (pid, proc_) in processes {
+        let name = proc_.name().to_str().unwrap_or("Other").to_string().to_lowercase();
+        let exe = proc_.exe().and_then(|path| path.to_str().map(|s| s.to_string()));
+        let process_cpu_usage = proc_.cpu_usage() as f64 / nb_cores as f64;
+        let process_gpu_usage = proc_gpu_usage.get(&pid.as_u32());
+        let mem = proc_.memory() as f64 / total_memory as f64 * 100.0;
+        let disk = proc_.disk_usage();
 
-    processes.into_iter().take(number_processes).collect()
+        measured_processes.push(MeasuredProcessData {
+            pid: Some(pid.as_u32()),
+            app_name: name,
+            process_exe_path: exe,
+            process_cpu_usage,
+            process_gpu_usage: process_gpu_usage.copied(),
+            process_mem_usage: mem,
+            read_bytes: Byte::from(disk.read_bytes),
+            written_bytes: Byte::from(disk.written_bytes),
+        });
+    }
+    measured_processes
 }
 
-/// Groups OS processes by app name and estimates per-app energy.
-fn extract_and_group_processes(
-    processes: &HashMap<Pid, Process>,
-    total_memory: u64,
+/// Groups measured processes by app name and estimates per-app energy consumption.
+pub fn compute_processes_energy(
+    measured_processes: Vec<MeasuredProcessData>,
     cpu_energy: EnergyUj,
     cpu_usage: f64,
-    nb_cores: usize,
     gpu_energy: EnergyUj,
     gpu_usage: f64,
     total_energy: EnergyUj,
-    proc_gpu_usage: HashMap<u32, f64>,
 ) -> Vec<ProcessData> {
     let mut grouped: HashMap<String, ProcessData> = HashMap::new();
 
@@ -75,23 +71,15 @@ fn extract_and_group_processes(
     let total_energy_f = total_energy.as_f64();
     let total_compute_energy_f = cpu_energy_f + gpu_energy_f;
 
-    for (pid, proc_) in processes {
-        let name = proc_.name().to_str().unwrap_or("Other").to_string().to_lowercase();
-        let exe = proc_.exe().and_then(|path| path.to_str().map(|s| s.to_string()));
-        // CPU usage percentage for this process as it would appear in a task manager (normalized by number of cores)
-        let process_cpu_usage = proc_.cpu_usage() as f64 / nb_cores as f64;
-        let process_gpu_usage = proc_gpu_usage.get(&pid.as_u32());
-        let mem = proc_.memory() as f64 / total_memory as f64 * 100.0;
-        let disk = proc_.disk_usage();
-
+    for measured_process in &measured_processes {
         let process_cpu_energy = if cpu_usage > 0.0 {
-            (process_cpu_usage / cpu_usage) * cpu_energy_f
+            (measured_process.process_cpu_usage / cpu_usage) * cpu_energy_f
         } else {
             0.0
         }
         .min(cpu_energy_f);
 
-        let process_gpu_energy = match process_gpu_usage {
+        let process_gpu_energy = match measured_process.process_gpu_usage {
             Some(gpu_usage_pct) if gpu_usage > 0.0 => (gpu_usage_pct / gpu_usage) * gpu_energy_f,
             _ => 0.0,
         }
@@ -108,26 +96,38 @@ fn extract_and_group_processes(
         let process_energy = EnergyUj::from_f64(process_energy_f);
 
         // Group by application name
-        let entry = grouped.entry(name.clone()).or_insert_with(ProcessData::default);
+        let entry = grouped
+            .entry(measured_process.app_name.clone())
+            .or_insert_with(ProcessData::default);
         if entry.measured.app_name.is_empty() {
-            entry.measured.app_name = name;
+            entry.measured.app_name = measured_process.app_name.clone();
         }
         entry.process_energy += process_energy;
-        entry.measured.process_cpu_usage += process_cpu_usage;
-        if let Some(gpu_usage) = process_gpu_usage {
+        entry.measured.process_cpu_usage += measured_process.process_cpu_usage;
+        if let Some(gpu_usage) = measured_process.process_gpu_usage {
             match entry.measured.process_gpu_usage {
                 Some(current_gpu_usage) => entry.measured.process_gpu_usage = Some(current_gpu_usage + gpu_usage),
-                None => entry.measured.process_gpu_usage = Some(*gpu_usage),
+                None => entry.measured.process_gpu_usage = Some(gpu_usage),
             }
         }
-        entry.measured.process_mem_usage += mem;
-        entry.measured.read_bytes += disk.read_bytes;
-        entry.measured.written_bytes += disk.written_bytes;
+        entry.measured.process_mem_usage += measured_process.process_mem_usage;
+        entry.measured.read_bytes += measured_process.read_bytes;
+        entry.measured.written_bytes += measured_process.written_bytes;
         entry.subprocess_count += 1;
-        if entry.measured.process_exe_path.is_none() && exe.is_some() {
-            entry.measured.process_exe_path = exe;
+        if entry.measured.process_exe_path.is_none() && measured_process.process_exe_path.is_some() {
+            entry.measured.process_exe_path = measured_process.process_exe_path.clone();
         }
     }
 
     grouped.into_iter().map(|(_, data)| data).collect()
+}
+
+/// Sorts the processes by estimated energy consumption in descending order.
+pub fn sort_processes_by_energy(mut processes: Vec<ProcessData>) -> Vec<ProcessData> {
+    processes.sort_by(|a, b| {
+        b.process_energy
+            .partial_cmp(&a.process_energy)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    processes
 }

--- a/collector/src/sensors/process.rs
+++ b/collector/src/sensors/process.rs
@@ -109,23 +109,23 @@ fn extract_and_group_processes(
 
         // Group by application name
         let entry = grouped.entry(name.clone()).or_insert_with(ProcessData::default);
-        if entry.app_name.is_empty() {
-            entry.app_name = name;
+        if entry.measured.app_name.is_empty() {
+            entry.measured.app_name = name;
         }
         entry.process_energy += process_energy;
-        entry.process_cpu_usage += process_cpu_usage;
+        entry.measured.process_cpu_usage += process_cpu_usage;
         if let Some(gpu_usage) = process_gpu_usage {
-            match entry.process_gpu_usage {
-                Some(current_gpu_usage) => entry.process_gpu_usage = Some(current_gpu_usage + gpu_usage),
-                None => entry.process_gpu_usage = Some(*gpu_usage),
+            match entry.measured.process_gpu_usage {
+                Some(current_gpu_usage) => entry.measured.process_gpu_usage = Some(current_gpu_usage + gpu_usage),
+                None => entry.measured.process_gpu_usage = Some(*gpu_usage),
             }
         }
-        entry.process_mem_usage += mem;
-        entry.read_bytes += disk.read_bytes;
-        entry.written_bytes += disk.written_bytes;
+        entry.measured.process_mem_usage += mem;
+        entry.measured.read_bytes += disk.read_bytes;
+        entry.measured.written_bytes += disk.written_bytes;
         entry.subprocess_count += 1;
-        if entry.process_exe_path.is_none() && exe.is_some() {
-            entry.process_exe_path = exe;
+        if entry.measured.process_exe_path.is_none() && exe.is_some() {
+            entry.measured.process_exe_path = exe;
         }
     }
 

--- a/common/src/database/entries.rs
+++ b/common/src/database/entries.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use rusqlite::{Row, ToSql};
 
-use crate::types::{AllTimeData, CPUData, DiskData, GPUData, NetworkData, ProcessData, RamData, SensorData, TotalData};
+use crate::types::{
+    AllTimeData, CPUData, ComputedSensorData, DiskData, GPUData, NetworkData, ProcessData, RamData, TotalData,
+};
 
 /// Maps a data type to its SQLite table schema and row conversion.
 pub trait DatabaseEntry {
@@ -14,9 +16,9 @@ pub trait DatabaseEntry {
     where
         Self: Sized;
 
-    fn zero() -> SensorData
+    fn zero() -> ComputedSensorData
     where
-        Self: Default + Into<SensorData>,
+        Self: Default + Into<ComputedSensorData>,
     {
         Self::default().into()
     }
@@ -173,24 +175,61 @@ impl_database_entry! {
     }
 }
 
-impl_database_entry! {
-    struct ProcessData {
-        generic_name: "Processes",
-        table_name: "process_data",
-        mappings: {
-            app_name: "app_name" => "TEXT NOT NULL",
-            process_exe_path: "process_exe_path" => "TEXT",
-            process_energy: "process_energy_uj" => "INTEGER",
-            process_cpu_usage: "process_cpu_usage" => "REAL",
-            process_gpu_usage: "process_gpu_usage" => "REAL",
-            process_mem_usage: "process_mem_usage" => "REAL",
-            read_bytes: "read_bytes" => "INTEGER",
-            written_bytes: "written_bytes" => "INTEGER",
-            subprocess_count: "subprocess_count" => "INTEGER",
-        },
-        extra_fields: {
+impl DatabaseEntry for ProcessData {
+    fn generic_name() -> &'static str {
+        "Processes"
+    }
+
+    fn table_name_static() -> &'static str {
+        "process_data"
+    }
+
+    fn columns_static() -> &'static [(&'static str, &'static str)] {
+        &[
+            ("app_name", "TEXT NOT NULL"),
+            ("process_exe_path", "TEXT"),
+            ("process_energy_uj", "INTEGER"),
+            ("process_cpu_usage", "REAL"),
+            ("process_gpu_usage", "REAL"),
+            ("process_mem_usage", "REAL"),
+            ("read_bytes", "INTEGER"),
+            ("written_bytes", "INTEGER"),
+            ("subprocess_count", "INTEGER"),
+        ]
+    }
+
+    fn insert_params<'a>(&'a self, timestamp_id: &'a i64) -> Vec<&'a dyn ToSql> {
+        vec![
+            timestamp_id,
+            &self.measured.app_name,
+            &self.measured.process_exe_path,
+            &self.process_energy,
+            &self.measured.process_cpu_usage,
+            &self.measured.process_gpu_usage,
+            &self.measured.process_mem_usage,
+            &self.measured.read_bytes,
+            &self.measured.written_bytes,
+            &self.subprocess_count,
+        ]
+    }
+
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        use crate::types::MeasuredProcessData;
+        Ok(Self {
+            measured: MeasuredProcessData {
+                pid: None,
+                app_name: row.get("app_name")?,
+                process_exe_path: row.get("process_exe_path")?,
+                process_cpu_usage: row.get("process_cpu_usage")?,
+                process_gpu_usage: row.get("process_gpu_usage")?,
+                process_mem_usage: row.get("process_mem_usage")?,
+                read_bytes: row.get("read_bytes")?,
+                written_bytes: row.get("written_bytes")?,
+            },
+            process_energy: row.get("process_energy_uj")?,
+            subprocess_count: row.get("subprocess_count")?,
             icon: None,
-        }
+        })
     }
 }
 
@@ -217,14 +256,16 @@ impl DatabaseEntry for AllTimeData {
 
 #[cfg(test)]
 mod tests {
-    use super::{CPUData, DatabaseEntry, DiskData, GPUData, NetworkData, ProcessData, RamData, SensorData, TotalData};
+    use super::{
+        CPUData, ComputedSensorData, DatabaseEntry, DiskData, GPUData, NetworkData, ProcessData, RamData, TotalData,
+    };
     use crate::types::{Byte, EnergyUj};
 
     #[test]
     fn zero_defaults_are_zero_filled() {
         // CPU
         match CPUData::zero() {
-            SensorData::CPU(cpu) => {
+            ComputedSensorData::CPU(cpu) => {
                 assert_eq!(cpu.total_energy, Some(EnergyUj::from_u64(0)));
                 assert_eq!(cpu.pp0_energy, Some(EnergyUj::from_u64(0)));
                 assert_eq!(cpu.pp1_energy, Some(EnergyUj::from_u64(0)));
@@ -236,7 +277,7 @@ mod tests {
 
         // GPU
         match GPUData::zero() {
-            SensorData::GPU(gpu) => {
+            ComputedSensorData::GPU(gpu) => {
                 assert_eq!(gpu.total_energy, Some(EnergyUj::from_u64(0)));
                 assert_eq!(gpu.usage_percent, Some(0.0));
                 assert_eq!(gpu.vram_usage_percent, Some(0.0));
@@ -246,7 +287,7 @@ mod tests {
 
         // RAM
         match RamData::zero() {
-            SensorData::Ram(ram) => {
+            ComputedSensorData::Ram(ram) => {
                 assert_eq!(ram.total_energy, Some(EnergyUj::from_u64(0)));
                 assert_eq!(ram.usage_percent, Some(0.0));
             }
@@ -255,7 +296,7 @@ mod tests {
 
         // Disk
         match DiskData::zero() {
-            SensorData::Disk(disk) => {
+            ComputedSensorData::Disk(disk) => {
                 assert_eq!(disk.total_energy, Some(EnergyUj::from_u64(0)));
                 assert_eq!(disk.read_bytes, Byte::from(0));
                 assert_eq!(disk.written_bytes, Byte::from(0));
@@ -265,7 +306,7 @@ mod tests {
 
         // Network
         match NetworkData::zero() {
-            SensorData::Network(net) => {
+            ComputedSensorData::Network(net) => {
                 assert_eq!(net.total_energy, Some(EnergyUj::from_u64(0)));
                 assert_eq!(net.downloaded_bytes, Byte::from(0));
                 assert_eq!(net.uploaded_bytes, Byte::from(0));
@@ -275,7 +316,7 @@ mod tests {
 
         // Total
         match TotalData::zero() {
-            SensorData::Total(total) => {
+            ComputedSensorData::Total(total) => {
                 assert_eq!(total.total_energy, EnergyUj::from_u64(0));
             }
             _ => panic!("TotalData::zero() returned wrong SensorData variant"),
@@ -283,7 +324,7 @@ mod tests {
 
         // Process
         match ProcessData::zero() {
-            SensorData::Process(vec) => {
+            ComputedSensorData::Process(vec) => {
                 assert!(vec.is_empty());
             }
             _ => panic!("ProcessData::zero() returned wrong SensorData variant"),

--- a/common/src/database/mod.rs
+++ b/common/src/database/mod.rs
@@ -766,59 +766,29 @@ impl Database {
         let now_ms = to_epoch_millis(SystemTime::now())?;
         let start = now_ms - n_seconds * 1000;
 
-        let query = "SELECT \
-                ?2 AS timestamp, \
-                combined.app_name AS app_name, \
-                MAX(combined.process_exe_path) AS process_exe_path, \
-                CAST(SUM(combined.energy_uj) AS INTEGER) AS process_energy_uj, \
-                SUM(combined.cpu_contrib)  / ?4 AS process_cpu_usage, \
-                SUM(combined.gpu_contrib)  / ?4 AS process_gpu_usage, \
-                SUM(combined.mem_contrib)  / ?4 AS process_mem_usage, \
-                CAST(SUM(combined.read_contrib)  / ?4 AS INTEGER) AS read_bytes, \
-                CAST(SUM(combined.write_contrib) / ?4 AS INTEGER) AS written_bytes, \
-                CAST(MAX(combined.subprocess_count) AS INTEGER) AS subprocess_count \
-             FROM ( \
-                 SELECT \
-                     p.app_name, p.process_exe_path, \
-                     COALESCE(p.process_energy_uj, 0) AS energy_uj, \
-                     COALESCE(p.process_cpu_usage, 0.0) AS cpu_contrib, \
-                     COALESCE(p.process_gpu_usage, 0.0) AS gpu_contrib, \
-                     COALESCE(p.process_mem_usage, 0.0) AS mem_contrib, \
-                     COALESCE(p.read_bytes,    0) AS read_contrib, \
-                     COALESCE(p.written_bytes, 0) AS write_contrib, \
-                     p.subprocess_count \
-                 FROM timestamp t JOIN process_data p ON t.id = p.timestamp_id \
-                 WHERE t.sampling_period = ?5 \
-                   AND t.timestamp >= ?1 AND t.timestamp < ?2 \
-                 UNION ALL \
-                 SELECT \
-                     p.app_name, p.process_exe_path, \
-                     COALESCE(p.process_energy_uj, 0) AS energy_uj, \
-                     COALESCE(p.process_cpu_usage, 0.0) * ?6 AS cpu_contrib, \
-                     COALESCE(p.process_gpu_usage, 0.0) * ?6 AS gpu_contrib, \
-                     COALESCE(p.process_mem_usage, 0.0) * ?6 AS mem_contrib, \
-                     COALESCE(p.read_bytes, 0) AS read_contrib, \
-                     COALESCE(p.written_bytes, 0) AS write_contrib, \
-                     p.subprocess_count \
-                 FROM timestamp t JOIN process_data p ON t.id = p.timestamp_id \
-                 WHERE t.sampling_period = ?6 \
-                   AND t.timestamp >= ?1 AND t.timestamp < ?2 \
-             ) combined \
-             GROUP BY combined.app_name \
-             ORDER BY process_energy_uj DESC \
-             LIMIT ?3";
+        let query = "\
+                SELECT \
+                    ?2 AS timestamp, \
+                    p.app_name AS app_name, \
+                    MAX(p.process_exe_path) AS process_exe_path, \
+                    CAST(SUM(COALESCE(p.process_energy_uj, 0)) AS INTEGER) AS process_energy_uj, \
+                    MIN(SUM(COALESCE(p.process_cpu_usage, 0.0) * t.sampling_period) / SUM(t.sampling_period), 100.0) AS process_cpu_usage, \
+                    MIN(SUM(COALESCE(p.process_gpu_usage, 0.0) * t.sampling_period) / SUM(t.sampling_period), 100.0) AS process_gpu_usage, \
+                    MIN(SUM(COALESCE(p.process_mem_usage, 0.0) * t.sampling_period) / SUM(t.sampling_period), 100.0) AS process_mem_usage, \
+                    CAST(SUM(COALESCE(p.read_bytes, 0)) * 1.0 / SUM(t.sampling_period) AS INTEGER) AS read_bytes, \
+                    CAST(SUM(COALESCE(p.written_bytes, 0)) * 1.0 / SUM(t.sampling_period) AS INTEGER) AS written_bytes, \
+                    CAST(MAX(p.subprocess_count) AS INTEGER) AS subprocess_count \
+                FROM timestamp t \
+                JOIN process_data p ON t.id = p.timestamp_id \
+                WHERE t.timestamp >= ?1 AND t.timestamp < ?2 \
+                GROUP BY p.app_name \
+                ORDER BY process_energy_uj DESC \
+                LIMIT ?3";
 
         let rows = self.execute_sensor_query(
             ProcessData::table_name_static(),
             query,
-            rusqlite::params![
-                start,
-                now_ms,
-                top_n as i64,
-                n_seconds as f64,
-                LIVE_SAMPLING_PERIOD_SECONDS,
-                HOURLY_SAMPLING_PERIOD_SECONDS
-            ],
+            rusqlite::params![start, now_ms, top_n as i64],
         )?;
 
         let mut processes = Vec::new();

--- a/common/src/database/mod.rs
+++ b/common/src/database/mod.rs
@@ -12,8 +12,8 @@ use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use crate::{
     AllTimeData,
     types::{
-        CPUData, DiskData, EnergyUj, Event, GPUData, GeneralData, HardwareInfo, NetworkData, ProcessData, RamData,
-        SensorData, TotalData,
+        CPUData, ComputedSensorData, DiskData, EnergyUj, Event, GPUData, GeneralData, HardwareInfo, NetworkData,
+        ProcessData, RamData, TotalData,
     },
 };
 
@@ -53,13 +53,13 @@ macro_rules! dispatch_entry {
 macro_rules! match_sensor_variant {
     ($val:expr, $inner:ident => $body:expr) => {
         match $val {
-            SensorData::CPU($inner) => $body,
-            SensorData::GPU($inner) => $body,
-            SensorData::Ram($inner) => $body,
-            SensorData::Disk($inner) => $body,
-            SensorData::Network($inner) => $body,
-            SensorData::Total($inner) => $body,
-            SensorData::Process(processes) => {
+            ComputedSensorData::CPU($inner) => $body,
+            ComputedSensorData::GPU($inner) => $body,
+            ComputedSensorData::Ram($inner) => $body,
+            ComputedSensorData::Disk($inner) => $body,
+            ComputedSensorData::Network($inner) => $body,
+            ComputedSensorData::Total($inner) => $body,
+            ComputedSensorData::Process(processes) => {
                 for $inner in processes {
                     $body?;
                 }
@@ -258,7 +258,11 @@ impl Database {
     }
 
     /// Insert an event and update component energy totals in a single transaction.
-    pub fn insert_event_and_update_energy(&mut self, event: &Event, sampling_period: u32) -> Result<(), DatabaseError> {
+    pub fn insert_event_and_update_energy(
+        &mut self,
+        event: &Event<ComputedSensorData>,
+        sampling_period: u32,
+    ) -> Result<(), DatabaseError> {
         let tx = self.conn.transaction()?;
         tx.execute(
             "INSERT INTO timestamp (timestamp, sampling_period) VALUES (?1, ?2)",
@@ -287,7 +291,7 @@ impl Database {
     }
 
     /// Inserts a sensor event with all its readings.
-    pub fn insert_event(&mut self, event: &Event) -> Result<(), DatabaseError> {
+    pub fn insert_event(&mut self, event: &Event<ComputedSensorData>) -> Result<(), DatabaseError> {
         let tx = self.conn.transaction()?;
         tx.execute(
             "INSERT INTO timestamp (timestamp, sampling_period) VALUES (?1, ?2)",
@@ -394,7 +398,11 @@ impl Database {
         Ok(())
     }
 
-    fn insert_sensor_data(tx: &Transaction, timestamp_id: &i64, sensor_data: &SensorData) -> Result<(), DatabaseError> {
+    fn insert_sensor_data(
+        tx: &Transaction,
+        timestamp_id: &i64,
+        sensor_data: &ComputedSensorData,
+    ) -> Result<(), DatabaseError> {
         match_sensor_variant!(sensor_data, data => Self::insert_entry(tx, timestamp_id, data))
     }
 
@@ -411,7 +419,7 @@ impl Database {
         table_name: &str,
         start_time: SystemTime,
         end_time: SystemTime,
-    ) -> Result<Vec<(SystemTime, SensorData)>, DatabaseError> {
+    ) -> Result<Vec<(SystemTime, ComputedSensorData)>, DatabaseError> {
         let start_time_millis = to_epoch_millis(start_time)?;
         let end_time_millis = to_epoch_millis(end_time)?;
 
@@ -424,11 +432,11 @@ impl Database {
         &mut self,
         start_time: SystemTime,
         end_time: SystemTime,
-    ) -> Result<Vec<(SystemTime, SensorData)>, DatabaseError> {
+    ) -> Result<Vec<(SystemTime, ComputedSensorData)>, DatabaseError> {
         let start_time_millis = to_epoch_millis(start_time)?;
         let end_time_millis = to_epoch_millis(end_time)?;
 
-        let mut records = Vec::<(i64, SensorData)>::new();
+        let mut records = Vec::<(i64, ComputedSensorData)>::new();
         if let Some(tables) = &self.tables {
             for table_name in tables {
                 let mut table_records =
@@ -445,7 +453,7 @@ impl Database {
         n: i64,
         table_name: &str,
         window_seconds: i64,
-    ) -> Result<Vec<(SystemTime, SensorData)>, DatabaseError> {
+    ) -> Result<Vec<(SystemTime, ComputedSensorData)>, DatabaseError> {
         if n <= 0 || window_seconds <= 0 {
             return Ok(Vec::new());
         }
@@ -472,8 +480,8 @@ impl Database {
     }
 
     /// Returns the most recent N timestamped records.
-    pub fn select_last_n_records(&mut self, n: i64) -> Result<Vec<(SystemTime, SensorData)>, DatabaseError> {
-        let mut records = Vec::<(SystemTime, SensorData)>::new();
+    pub fn select_last_n_records(&mut self, n: i64) -> Result<Vec<(SystemTime, ComputedSensorData)>, DatabaseError> {
+        let mut records = Vec::<(SystemTime, ComputedSensorData)>::new();
         let mut stmt = self
             .conn
             .prepare("SELECT id, timestamp FROM timestamp ORDER BY id DESC LIMIT ?1")?;
@@ -544,16 +552,16 @@ impl Database {
         table_name: &str,
         query: &str,
         params: P,
-    ) -> rusqlite::Result<Vec<(i64, SensorData)>>
+    ) -> rusqlite::Result<Vec<(i64, ComputedSensorData)>>
     where
         P: rusqlite::Params,
     {
         dispatch_entry!(table_name, self, query_sensor_table, P, (query, params)).unwrap_or_else(|| Ok(Vec::new()))
     }
 
-    fn query_sensor_table<T, P>(&self, query: &str, params: P) -> rusqlite::Result<Vec<(i64, SensorData)>>
+    fn query_sensor_table<T, P>(&self, query: &str, params: P) -> rusqlite::Result<Vec<(i64, ComputedSensorData)>>
     where
-        T: DatabaseEntry + Into<SensorData>,
+        T: DatabaseEntry + Into<ComputedSensorData>,
         P: rusqlite::Params,
     {
         let mut stmt = self.conn.prepare(query)?;
@@ -571,7 +579,7 @@ impl Database {
         table_name: &str,
         start_time_millis: i64,
         end_time_millis: i64,
-    ) -> Result<Vec<(i64, SensorData)>, DatabaseError> {
+    ) -> Result<Vec<(i64, ComputedSensorData)>, DatabaseError> {
         if !is_valid_table_name(table_name) {
             return Err(DatabaseError::QueryError(format!(
                 "Rejected table name: {}",
@@ -593,7 +601,7 @@ impl Database {
         start_window_start: i64,
         end_exclusive: i64,
         window_seconds: i64,
-    ) -> Result<Vec<(i64, SensorData)>, DatabaseError> {
+    ) -> Result<Vec<(i64, ComputedSensorData)>, DatabaseError> {
         if !is_valid_table_name(table_name) {
             return Err(DatabaseError::QueryError(format!(
                 "Rejected table name: {}",
@@ -670,7 +678,7 @@ impl Database {
         start_window_start: i64,
         end_exclusive: i64,
         window_seconds: i64,
-    ) -> Result<Vec<(i64, SensorData)>, DatabaseError> {
+    ) -> Result<Vec<(i64, ComputedSensorData)>, DatabaseError> {
         let second_query = "SELECT \
                 (t.timestamp / (?2 * 1000)) * (?2 * 1000) AS window_start, \
                 CAST(SUM(COALESCE(d.total_energy_uj, 0)) / ?2 AS INTEGER) AS total_energy_uj \
@@ -733,7 +741,7 @@ impl Database {
             } else if let Some(hour_data) = hour_by_window.remove(&current) {
                 hour_data
             } else {
-                SensorData::Total(TotalData {
+                ComputedSensorData::Total(TotalData {
                     total_energy: EnergyUj::from_u64(0),
                 })
             };
@@ -750,9 +758,9 @@ impl Database {
         &self,
         n_seconds: i64,
         top_n: usize,
-    ) -> Result<Vec<(SystemTime, SensorData)>, DatabaseError> {
+    ) -> Result<Vec<(SystemTime, ComputedSensorData)>, DatabaseError> {
         if n_seconds == 0 {
-            return Ok(vec![(SystemTime::now(), SensorData::Process(Vec::new()))]);
+            return Ok(vec![(SystemTime::now(), ComputedSensorData::Process(Vec::new()))]);
         }
 
         let now_ms = to_epoch_millis(SystemTime::now())?;
@@ -815,11 +823,14 @@ impl Database {
 
         let mut processes = Vec::new();
         for (_, data) in rows {
-            if let SensorData::Process(mut proc_data) = data {
+            if let ComputedSensorData::Process(mut proc_data) = data {
                 processes.append(&mut proc_data);
             }
         }
-        Ok(vec![(from_epoch_millis(now_ms as i64), SensorData::Process(processes))])
+        Ok(vec![(
+            from_epoch_millis(now_ms as i64),
+            ComputedSensorData::Process(processes),
+        )])
     }
 }
 
@@ -880,7 +891,7 @@ fn windowed_column_expr(
     }
 }
 
-fn zero_sensor_data(table_name: &str) -> Option<SensorData> {
+fn zero_sensor_data(table_name: &str) -> Option<ComputedSensorData> {
     dispatch_entry!(table_name, zero())
 }
 
@@ -892,7 +903,7 @@ fn from_epoch_millis(ts_millis: i64) -> SystemTime {
     SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(ts_millis as u64)
 }
 
-fn to_system_time_records(records: Vec<(i64, SensorData)>) -> Vec<(SystemTime, SensorData)> {
+fn to_system_time_records(records: Vec<(i64, ComputedSensorData)>) -> Vec<(SystemTime, ComputedSensorData)> {
     records
         .into_iter()
         .map(|(ts_millis, data)| (from_epoch_millis(ts_millis), data))

--- a/common/src/database/mod.rs
+++ b/common/src/database/mod.rs
@@ -231,12 +231,12 @@ impl Database {
     }
 
     /// Creates sensor tables that don't already exist.
-    pub fn create_tables_if_not_exists(&mut self, table_names: &[&str]) -> Result<(), DatabaseError> {
+    pub fn create_tables_if_not_exists(&mut self, table_names: &Vec<String>) -> Result<(), DatabaseError> {
         let tx = self.conn.transaction()?;
 
         let mut current_tables = self.tables.clone().unwrap_or_default();
         let mut has_changed = false;
-        for &name in table_names {
+        for name in table_names {
             if !current_tables.contains(&name.to_string()) {
                 if let Some(create_sql) = dispatch_entry!(name, create_table_sql()) {
                     tx.execute_batch(&create_sql)?;
@@ -319,12 +319,12 @@ impl Database {
         if existing.is_some() {
             tx.execute(
                 "UPDATE hardware_info SET tables = ?1, hardware_data = ?2 WHERE id = 1",
-                params![data.tables, data.hardware_info_serialized],
+                params![data.tables, data.hardware_info.serialized()],
             )?;
         } else {
             tx.execute(
                 "INSERT INTO hardware_info (id, tables, hardware_data) VALUES (1, ?1, ?2)",
-                params![data.tables, data.hardware_info_serialized],
+                params![data.tables, data.hardware_info.serialized()],
             )?;
         }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -18,9 +18,9 @@ macro_rules! clog {
 pub use database::{DATABASE_PATH, Database, DatabaseEntry, DatabaseError, UiSettings, generic_name_for_table};
 pub use singleton::SingletonGuard;
 pub use types::{
-    AllTimeData, CPUData, DiskData, EnergyUj, Event, GPUData, GeneralData, HardwareInfo, IconData, LabeledValue,
-    MICROJOULES_PER_JOULE, MetricKind, NetworkData, ProcessData, RamData, SECONDS_PER_HOUR, SecondaryValues,
-    SensorData, TotalData,
+    AllTimeData, CPUData, ComputedSensorData, DiskData, EnergyUj, Event, GPUData, GeneralData, HardwareInfo, IconData,
+    LabeledValue, MICROJOULES_PER_JOULE, MetricKind, NetworkData, ProcessData, RamData, SECONDS_PER_HOUR,
+    SecondaryValues, SensorData, TotalData,
 };
 pub use utils::set_current_dir_to_exe_dir;
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -13,14 +13,14 @@ pub const SECONDS_PER_HOUR: f64 = 3600.0;
 
 /// Timestamped collection of sensor readings.
 #[derive(Debug, Clone)]
-pub struct Event {
+pub struct Event<T = SensorData> {
     time: SystemTime,
-    data: Vec<SensorData>,
+    data: Vec<T>,
 }
 
-impl Event {
+impl<T> Event<T> {
     /// Creates an event with the given timestamp and sensor data.
-    pub fn new(time: SystemTime, data: Vec<SensorData>) -> Self {
+    pub fn new(time: SystemTime, data: Vec<T>) -> Self {
         Event { time, data }
     }
 
@@ -30,17 +30,17 @@ impl Event {
     }
 
     /// Returns the list of sensor readings.
-    pub fn data(&self) -> &Vec<SensorData> {
+    pub fn data(&self) -> &Vec<T> {
         &self.data
     }
 
     /// Appends a sensor reading to this event.
-    pub fn push_data(&mut self, data: SensorData) {
+    pub fn push_data(&mut self, data: T) {
         self.data.push(data);
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct EnergyUj(u64);
 
 impl std::fmt::Display for EnergyUj {
@@ -152,7 +152,7 @@ impl std::ops::MulAssign<f64> for EnergyUj {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
 pub struct EnergyWh(f64);
 
 impl std::fmt::Display for EnergyWh {
@@ -165,7 +165,7 @@ impl std::fmt::Display for EnergyWh {
 pub struct PowerW(f64);
 
 //byte unit
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Byte(u64);
 
 impl Byte {
@@ -222,7 +222,7 @@ pub struct AllTimeData<E = EnergyUj> {
 }
 
 /// CPU energy and usage readings.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CPUData<E = EnergyUj> {
     pub total_energy: Option<E>,
     pub pp0_energy: Option<E>,
@@ -232,7 +232,7 @@ pub struct CPUData<E = EnergyUj> {
 }
 
 /// GPU energy and usage readings.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GPUData<E = EnergyUj> {
     pub total_energy: Option<E>,
     pub usage_percent: Option<f64>,
@@ -240,14 +240,14 @@ pub struct GPUData<E = EnergyUj> {
 }
 
 /// RAM energy and usage readings.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RamData<E = EnergyUj> {
     pub total_energy: Option<E>,
     pub usage_percent: Option<f64>,
 }
 
 /// Disk energy and I/O throughput readings.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiskData<E = EnergyUj> {
     pub total_energy: Option<E>,
     pub read_bytes: Byte,
@@ -255,7 +255,7 @@ pub struct DiskData<E = EnergyUj> {
 }
 
 /// Network energy and throughput readings.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkData<E = EnergyUj> {
     pub total_energy: Option<E>,
     pub downloaded_bytes: Byte,
@@ -263,31 +263,49 @@ pub struct NetworkData<E = EnergyUj> {
 }
 
 /// Raw RGBA icon pixel data.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IconData {
     pub width: u32,
     pub height: u32,
     pub pixels: Vec<u8>,
 }
 
-/// Per-application resource usage snapshot.
-#[derive(Debug, Clone, Serialize)]
-pub struct ProcessData<E = EnergyUj> {
+/// Measured process details (raw resource metrics).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeasuredProcessData {
+    pub pid: Option<u32>,
     pub app_name: String,
     pub process_exe_path: Option<String>,
-    pub process_energy: E,
     pub process_cpu_usage: f64,
     pub process_gpu_usage: Option<f64>,
     pub process_mem_usage: f64,
     pub read_bytes: Byte,
     pub written_bytes: Byte,
+}
+
+/// Per-application resource usage snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessData<E = EnergyUj> {
+    pub measured: MeasuredProcessData,
+    pub process_energy: E,
     pub subprocess_count: u32,
     pub icon: Option<IconData>,
 }
 
-/// Tagged union of all sensor reading types.
-#[derive(Debug, Clone, Serialize)]
+/// Tagged union of all raw measured sensor reading types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SensorData<E = EnergyUj> {
+    CPU(CPUData<E>),
+    GPU(GPUData<E>),
+    Ram(RamData<E>),
+    Disk(DiskData<E>),
+    Network(NetworkData<E>),
+    Process(Vec<MeasuredProcessData>),
+}
+
+/// Tagged union of all sensor reading types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ComputedSensorData<E = EnergyUj> {
     CPU(CPUData<E>),
     GPU(GPUData<E>),
     Ram(RamData<E>),
@@ -298,7 +316,7 @@ pub enum SensorData<E = EnergyUj> {
 }
 
 /// Aggregated total energy across all components.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TotalData<E = EnergyUj> {
     pub total_energy: E,
 }
@@ -545,21 +563,7 @@ impl SensorData {
             SensorData::Ram(_) => "RAM",
             SensorData::Disk(_) => "Disk",
             SensorData::Network(_) => "Network",
-            SensorData::Total(_) => "Total",
             SensorData::Process(_) => "Processes",
-        }
-    }
-
-    /// Returns the database table name for this variant.
-    pub fn table_name(&self) -> &'static str {
-        match self {
-            SensorData::CPU(_) => CPUData::table_name_static(),
-            SensorData::GPU(_) => GPUData::table_name_static(),
-            SensorData::Total(_) => TotalData::table_name_static(),
-            SensorData::Ram(_) => RamData::table_name_static(),
-            SensorData::Disk(_) => DiskData::table_name_static(),
-            SensorData::Network(_) => NetworkData::table_name_static(),
-            SensorData::Process(_) => ProcessData::table_name_static(),
         }
     }
 
@@ -571,7 +575,6 @@ impl SensorData {
             SensorData::Ram(data) => data.total_energy,
             SensorData::Disk(data) => data.total_energy,
             SensorData::Network(data) => data.total_energy,
-            SensorData::Total(power) => Some(power.total_energy),
             SensorData::Process(_) => None,
         }
     }
@@ -605,39 +608,77 @@ impl SensorData {
                 downloaded_bytes: data.downloaded_bytes,
                 uploaded_bytes: data.uploaded_bytes,
             }),
-            SensorData::Total(total) => SensorData::Total(TotalData {
-                total_energy: total.total_energy.to_wh(),
-            }),
-            SensorData::Process(processes) => SensorData::Process(
-                processes
-                    .iter()
-                    .map(|p| ProcessData {
-                        app_name: p.app_name.clone(),
-                        process_exe_path: p.process_exe_path.clone(),
-                        process_energy: p.process_energy.to_wh(),
-                        process_cpu_usage: p.process_cpu_usage,
-                        process_gpu_usage: p.process_gpu_usage,
-                        process_mem_usage: p.process_mem_usage,
-                        read_bytes: p.read_bytes,
-                        written_bytes: p.written_bytes,
-                        subprocess_count: p.subprocess_count,
-                        icon: p.icon.clone(),
-                    })
-                    .collect(),
-            ),
+            SensorData::Process(processes) => SensorData::Process(processes.to_vec()),
+        }
+    }
+}
+
+impl Display for SensorData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SensorData::CPU(data) => write!(f, "{}", data),
+            SensorData::GPU(data) => write!(f, "{}", data),
+            SensorData::Ram(data) => write!(f, "{}", data),
+            SensorData::Disk(data) => write!(f, "{}", data),
+            SensorData::Network(data) => write!(f, "{}", data),
+            SensorData::Process(processes) => {
+                writeln!(f, "Processes:")?;
+                for p in processes {
+                    writeln!(
+                        f,
+                        "- {} (PID: {:?}): CPU {}%, GPU {}%, Mem {}%, Read {}, Write {}",
+                        p.app_name,
+                        p.pid,
+                        p.process_cpu_usage,
+                        p.process_gpu_usage.map_or(0.0, |gpu| gpu),
+                        p.process_mem_usage,
+                        p.read_bytes,
+                        p.written_bytes
+                    )?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ComputedSensorData {
+    /// Returns the database table name for this variant.
+    pub fn table_name(&self) -> &'static str {
+        match self {
+            ComputedSensorData::CPU(_) => CPUData::table_name_static(),
+            ComputedSensorData::GPU(_) => GPUData::table_name_static(),
+            ComputedSensorData::Total(_) => TotalData::table_name_static(),
+            ComputedSensorData::Ram(_) => RamData::table_name_static(),
+            ComputedSensorData::Disk(_) => DiskData::table_name_static(),
+            ComputedSensorData::Network(_) => NetworkData::table_name_static(),
+            ComputedSensorData::Process(_) => ProcessData::table_name_static(),
+        }
+    }
+
+    /// Returns the total energy in µJ, if available.
+    pub fn total_energy(&self) -> Option<EnergyUj> {
+        match self {
+            ComputedSensorData::CPU(data) => data.total_energy,
+            ComputedSensorData::GPU(data) => data.total_energy,
+            ComputedSensorData::Ram(data) => data.total_energy,
+            ComputedSensorData::Disk(data) => data.total_energy,
+            ComputedSensorData::Network(data) => data.total_energy,
+            ComputedSensorData::Total(power) => Some(power.total_energy),
+            ComputedSensorData::Process(_) => None,
         }
     }
 
     /// Scales all energy fields by `factor`.
     pub fn scale_energy(&mut self, factor: f64) {
         match self {
-            SensorData::CPU(d) => d.total_energy = d.total_energy.map(|w| w * factor),
-            SensorData::GPU(d) => d.total_energy = d.total_energy.map(|w| w * factor),
-            SensorData::Ram(d) => d.total_energy = d.total_energy.map(|w| w * factor),
-            SensorData::Disk(d) => d.total_energy = d.total_energy.map(|w| w * factor),
-            SensorData::Network(d) => d.total_energy = d.total_energy.map(|w| w * factor),
-            SensorData::Total(d) => d.total_energy *= factor,
-            SensorData::Process(procs) => {
+            ComputedSensorData::CPU(d) => d.total_energy = d.total_energy.map(|w| w * factor),
+            ComputedSensorData::GPU(d) => d.total_energy = d.total_energy.map(|w| w * factor),
+            ComputedSensorData::Ram(d) => d.total_energy = d.total_energy.map(|w| w * factor),
+            ComputedSensorData::Disk(d) => d.total_energy = d.total_energy.map(|w| w * factor),
+            ComputedSensorData::Network(d) => d.total_energy = d.total_energy.map(|w| w * factor),
+            ComputedSensorData::Total(d) => d.total_energy *= factor,
+            ComputedSensorData::Process(procs) => {
                 for p in procs {
                     p.process_energy *= factor;
                 }
@@ -649,26 +690,26 @@ impl SensorData {
     pub fn secondary_values(&self) -> Option<SecondaryValues> {
         let metric_type = self.secondary_metric()?;
         match self {
-            SensorData::CPU(data) => Some(SecondaryValues::from_labeled_values(
+            ComputedSensorData::CPU(data) => Some(SecondaryValues::from_labeled_values(
                 metric_type,
                 vec![LabeledValue::from_usage_percent(data.usage_percent)],
             )),
-            SensorData::GPU(data) => Some(SecondaryValues::from_labeled_values(
+            ComputedSensorData::GPU(data) => Some(SecondaryValues::from_labeled_values(
                 metric_type,
                 vec![LabeledValue::from_usage_percent(data.usage_percent)],
             )),
-            SensorData::Ram(data) => Some(SecondaryValues::from_labeled_values(
+            ComputedSensorData::Ram(data) => Some(SecondaryValues::from_labeled_values(
                 metric_type,
                 vec![LabeledValue::from_usage_percent(data.usage_percent)],
             )),
-            SensorData::Disk(data) => Some(SecondaryValues::from_labeled_values(
+            ComputedSensorData::Disk(data) => Some(SecondaryValues::from_labeled_values(
                 metric_type,
                 vec![
                     LabeledValue::from_mb_s(Some(data.read_bytes.as_mb()), "Read"),
                     LabeledValue::from_mb_s(Some(data.written_bytes.as_mb()), "Write"),
                 ],
             )),
-            SensorData::Network(data) => Some(SecondaryValues::from_labeled_values(
+            ComputedSensorData::Network(data) => Some(SecondaryValues::from_labeled_values(
                 metric_type,
                 vec![
                     LabeledValue::from_mb_s(Some(data.downloaded_bytes.as_mb()), "Download"),
@@ -682,54 +723,25 @@ impl SensorData {
     /// Returns the secondary metric type for this sensor variant.
     pub fn secondary_metric(&self) -> Option<MetricKind> {
         match self {
-            SensorData::CPU(_) | SensorData::GPU(_) | SensorData::Ram(_) => Some(MetricKind::Usage),
-            SensorData::Disk(_) | SensorData::Network(_) => Some(MetricKind::Speed),
+            ComputedSensorData::CPU(_) | ComputedSensorData::GPU(_) | ComputedSensorData::Ram(_) => {
+                Some(MetricKind::Usage)
+            }
+            ComputedSensorData::Disk(_) | ComputedSensorData::Network(_) => Some(MetricKind::Speed),
             _ => None,
         }
     }
 }
 
-impl Display for SensorData {
+impl Display for ComputedSensorData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SensorData::CPU(data) => {
-                writeln!(f, "CPU Data:")?;
-                writeln!(f, "  Energy PKG:  {}", data.total_energy.unwrap_or_default())?;
-                writeln!(f, "  Energy PP0:  {}", data.pp0_energy.unwrap_or_default())?;
-                writeln!(f, "  Energy PP1:  {}", data.pp1_energy.unwrap_or_default())?;
-                writeln!(f, "  Energy DRAM: {}", data.dram_energy.unwrap_or_default())?;
-                writeln!(f, "  Usage:       {:.2} %", data.usage_percent.unwrap_or(-1.0))?;
-                Ok(())
-            }
-            SensorData::GPU(data) => {
-                writeln!(f, "GPU Data:")?;
-                writeln!(f, "  Energy:      {}", data.total_energy.unwrap_or_default())?;
-                writeln!(f, "  Usage:       {:.2} %", data.usage_percent.unwrap_or(-1.0))?;
-                writeln!(f, "  VRAM Usage:  {:.2} %", data.vram_usage_percent.unwrap_or(-1.0))?;
-                Ok(())
-            }
-            SensorData::Ram(data) => {
-                writeln!(f, "RAM Data:")?;
-                writeln!(f, "  Energy: {}", data.total_energy.unwrap_or_default())?;
-                writeln!(f, "  Usage:  {:.2} %", data.usage_percent.unwrap_or(-1.0))?;
-                Ok(())
-            }
-            SensorData::Disk(data) => {
-                writeln!(f, "Disk Data:")?;
-                writeln!(f, "  Energy: {}", data.total_energy.unwrap_or_default())?;
-                writeln!(f, "  Read:   {:.2} MB", data.read_bytes.as_mb())?;
-                writeln!(f, "  Write:  {:.2} MB", data.written_bytes.as_mb())?;
-                Ok(())
-            }
-            SensorData::Network(data) => {
-                writeln!(f, "Network Data:")?;
-                writeln!(f, "  Energy:   {}", data.total_energy.unwrap_or_default())?;
-                writeln!(f, "  Download: {:.2} MB", data.downloaded_bytes.as_mb())?;
-                writeln!(f, "  Upload:   {:.2} MB", data.uploaded_bytes.as_mb())?;
-                Ok(())
-            }
-            SensorData::Total(total) => writeln!(f, "Total Energy: {}", total.total_energy),
-            SensorData::Process(processes) => {
+            ComputedSensorData::CPU(data) => write!(f, "{}", data),
+            ComputedSensorData::GPU(data) => write!(f, "{}", data),
+            ComputedSensorData::Ram(data) => write!(f, "{}", data),
+            ComputedSensorData::Disk(data) => write!(f, "{}", data),
+            ComputedSensorData::Network(data) => write!(f, "{}", data),
+            ComputedSensorData::Total(total) => writeln!(f, "Total Energy: {}", total.total_energy),
+            ComputedSensorData::Process(processes) => {
                 writeln!(f, "Top Processes by CPU Usage:")?;
                 writeln!(
                     f,
@@ -752,16 +764,89 @@ impl Display for ProcessData {
         writeln!(
             f,
             "{:<30.30} {:>10.2} {:>10.2} {:>10.2} {:>16} {:>15.2} {:>15.2} {:>20}",
-            self.app_name,
-            self.process_cpu_usage,
-            self.process_gpu_usage.unwrap_or(0.0),
-            self.process_mem_usage,
+            self.measured.app_name,
+            self.measured.process_cpu_usage,
+            self.measured.process_gpu_usage.unwrap_or(0.0),
+            self.measured.process_mem_usage,
             energy_str,
-            self.read_bytes.as_mb(),
-            self.written_bytes.as_mb(),
+            self.measured.read_bytes.as_mb(),
+            self.measured.written_bytes.as_mb(),
             self.subprocess_count
         )?;
         Ok(())
+    }
+}
+
+impl Display for CPUData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "CPU Data:")?;
+        writeln!(f, "  Energy PKG:  {}", self.total_energy.unwrap_or_default())?;
+        writeln!(f, "  Energy PP0:  {}", self.pp0_energy.unwrap_or_default())?;
+        writeln!(f, "  Energy PP1:  {}", self.pp1_energy.unwrap_or_default())?;
+        writeln!(f, "  Energy DRAM: {}", self.dram_energy.unwrap_or_default())?;
+        writeln!(f, "  Usage:       {:.2} %", self.usage_percent.unwrap_or(-1.0))?;
+        Ok(())
+    }
+}
+
+impl Display for GPUData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "GPU Data:")?;
+        writeln!(f, "  Energy:      {}", self.total_energy.unwrap_or_default())?;
+        writeln!(f, "  Usage:       {:.2} %", self.usage_percent.unwrap_or(-1.0))?;
+        writeln!(f, "  VRAM Usage:  {:.2} %", self.vram_usage_percent.unwrap_or(-1.0))?;
+        Ok(())
+    }
+}
+
+impl Display for RamData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "RAM Data:")?;
+        writeln!(f, "  Energy: {}", self.total_energy.unwrap_or_default())?;
+        writeln!(f, "  Usage:  {:.2} %", self.usage_percent.unwrap_or(-1.0))?;
+        Ok(())
+    }
+}
+
+impl Display for DiskData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Disk Data:")?;
+        writeln!(f, "  Energy: {}", self.total_energy.unwrap_or_default())?;
+        writeln!(f, "  Read:   {:.2} MB", self.read_bytes.as_mb())?;
+        writeln!(f, "  Write:  {:.2} MB", self.written_bytes.as_mb())?;
+        Ok(())
+    }
+}
+
+impl Display for NetworkData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Network Data:")?;
+        writeln!(f, "  Energy:   {}", self.total_energy.unwrap_or_default())?;
+        writeln!(f, "  Download: {:.2} MB", self.downloaded_bytes.as_mb())?;
+        writeln!(f, "  Upload:   {:.2} MB", self.uploaded_bytes.as_mb())?;
+        Ok(())
+    }
+}
+
+impl From<SensorData> for ComputedSensorData {
+    fn from(data: SensorData) -> Self {
+        match data {
+            SensorData::CPU(cpu) => ComputedSensorData::CPU(cpu),
+            SensorData::GPU(gpu) => ComputedSensorData::GPU(gpu),
+            SensorData::Ram(ram) => ComputedSensorData::Ram(ram),
+            SensorData::Disk(disk) => ComputedSensorData::Disk(disk),
+            SensorData::Network(network) => ComputedSensorData::Network(network),
+            SensorData::Process(processes) => {
+                let computed_processes = processes
+                    .into_iter()
+                    .map(|p| ProcessData {
+                        measured: p,
+                        ..Default::default()
+                    })
+                    .collect();
+                ComputedSensorData::Process(computed_processes)
+            }
+        }
     }
 }
 
@@ -771,15 +856,27 @@ impl From<CPUData> for SensorData {
     }
 }
 
+impl From<CPUData> for ComputedSensorData {
+    fn from(data: CPUData) -> Self {
+        ComputedSensorData::CPU(data)
+    }
+}
+
 impl From<GPUData> for SensorData {
     fn from(data: GPUData) -> Self {
         SensorData::GPU(data)
     }
 }
 
-impl From<TotalData> for SensorData {
+impl From<GPUData> for ComputedSensorData {
+    fn from(data: GPUData) -> Self {
+        ComputedSensorData::GPU(data)
+    }
+}
+
+impl From<TotalData> for ComputedSensorData {
     fn from(data: TotalData) -> Self {
-        SensorData::Total(data)
+        ComputedSensorData::Total(data)
     }
 }
 
@@ -788,24 +885,50 @@ impl From<RamData> for SensorData {
         SensorData::Ram(data)
     }
 }
+
+impl From<RamData> for ComputedSensorData {
+    fn from(data: RamData) -> Self {
+        ComputedSensorData::Ram(data)
+    }
+}
+
 impl From<DiskData> for SensorData {
     fn from(data: DiskData) -> Self {
         SensorData::Disk(data)
     }
 }
+
+impl From<DiskData> for ComputedSensorData {
+    fn from(data: DiskData) -> Self {
+        ComputedSensorData::Disk(data)
+    }
+}
+
 impl From<NetworkData> for SensorData {
     fn from(data: NetworkData) -> Self {
         SensorData::Network(data)
     }
 }
 
-impl From<ProcessData> for SensorData {
-    fn from(data: ProcessData) -> Self {
+impl From<NetworkData> for ComputedSensorData {
+    fn from(data: NetworkData) -> Self {
+        ComputedSensorData::Network(data)
+    }
+}
+
+impl From<MeasuredProcessData> for SensorData {
+    fn from(data: MeasuredProcessData) -> Self {
         if data.app_name.is_empty() {
             SensorData::Process(Vec::new())
         } else {
             SensorData::Process(vec![data])
         }
+    }
+}
+
+impl From<ProcessData> for ComputedSensorData {
+    fn from(data: ProcessData) -> Self {
+        ComputedSensorData::Process(vec![data])
     }
 }
 
@@ -860,17 +983,26 @@ impl Default for NetworkData {
     }
 }
 
-impl Default for ProcessData {
+impl Default for MeasuredProcessData {
     fn default() -> Self {
-        ProcessData {
+        MeasuredProcessData {
+            pid: None,
             app_name: String::new(),
             process_exe_path: None,
-            process_energy: EnergyUj(0),
             process_cpu_usage: 0.0,
             process_gpu_usage: None,
             process_mem_usage: 0.0,
             read_bytes: Byte(0),
             written_bytes: Byte(0),
+        }
+    }
+}
+
+impl Default for ProcessData {
+    fn default() -> Self {
+        ProcessData {
+            measured: MeasuredProcessData::default(),
+            process_energy: EnergyUj(0),
             subprocess_count: 0,
             icon: None,
         }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -333,10 +333,10 @@ pub enum InitialInfo {
 }
 
 /// Database metadata pairing table list with serialized hardware info.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GeneralData {
     pub tables: String,
-    pub hardware_info_serialized: String,
+    pub hardware_info: HardwareInfo,
 }
 
 /// Complete hardware inventory of the system.
@@ -656,6 +656,64 @@ impl ComputedSensorData {
         }
     }
 
+    pub fn sensor_type(&self) -> &'static str {
+        match self {
+            ComputedSensorData::CPU(_) => "CPU",
+            ComputedSensorData::GPU(_) => "GPU",
+            ComputedSensorData::Ram(_) => "RAM",
+            ComputedSensorData::Disk(_) => "Disk",
+            ComputedSensorData::Network(_) => "Network",
+            ComputedSensorData::Total(_) => "Total",
+            ComputedSensorData::Process(_) => "Processes",
+        }
+    }
+
+    pub fn to_wh(&self) -> ComputedSensorData<EnergyWh> {
+        match self {
+            ComputedSensorData::CPU(data) => ComputedSensorData::CPU(CPUData {
+                total_energy: data.total_energy.map(|e| e.to_wh()),
+                pp0_energy: data.pp0_energy.map(|e| e.to_wh()),
+                pp1_energy: data.pp1_energy.map(|e| e.to_wh()),
+                dram_energy: data.dram_energy.map(|e| e.to_wh()),
+                usage_percent: data.usage_percent,
+            }),
+            ComputedSensorData::GPU(data) => ComputedSensorData::GPU(GPUData {
+                total_energy: data.total_energy.map(|e| e.to_wh()),
+                usage_percent: data.usage_percent,
+                vram_usage_percent: data.vram_usage_percent,
+            }),
+            ComputedSensorData::Ram(data) => ComputedSensorData::Ram(RamData {
+                total_energy: data.total_energy.map(|e| e.to_wh()),
+                usage_percent: data.usage_percent,
+            }),
+            ComputedSensorData::Disk(data) => ComputedSensorData::Disk(DiskData {
+                total_energy: data.total_energy.map(|e| e.to_wh()),
+                read_bytes: data.read_bytes,
+                written_bytes: data.written_bytes,
+            }),
+            ComputedSensorData::Network(data) => ComputedSensorData::Network(NetworkData {
+                total_energy: data.total_energy.map(|e| e.to_wh()),
+                downloaded_bytes: data.downloaded_bytes,
+                uploaded_bytes: data.uploaded_bytes,
+            }),
+            ComputedSensorData::Total(total) => ComputedSensorData::Total(TotalData {
+                total_energy: total.total_energy.to_wh(),
+            }),
+            ComputedSensorData::Process(processes) => {
+                let converted_processes = processes
+                    .iter()
+                    .map(|p| ProcessData {
+                        measured: p.measured.clone(),
+                        process_energy: p.process_energy.to_wh(),
+                        subprocess_count: p.subprocess_count,
+                        icon: p.icon.clone(),
+                    })
+                    .collect();
+                ComputedSensorData::Process(converted_processes)
+            }
+        }
+    }
+
     /// Returns the total energy in µJ, if available.
     pub fn total_energy(&self) -> Option<EnergyUj> {
         match self {
@@ -754,6 +812,32 @@ impl Display for ComputedSensorData {
                 Ok(())
             }
         }
+    }
+}
+
+pub trait PublishableSensor: Serialize {
+    type Wh: Serialize;
+    fn sensor_type(&self) -> &'static str;
+    fn to_wh(&self) -> Self::Wh;
+}
+
+impl PublishableSensor for SensorData {
+    type Wh = SensorData<EnergyWh>;
+    fn sensor_type(&self) -> &'static str {
+        SensorData::sensor_type(self)
+    }
+    fn to_wh(&self) -> Self::Wh {
+        SensorData::to_wh(self)
+    }
+}
+
+impl PublishableSensor for ComputedSensorData {
+    type Wh = ComputedSensorData<EnergyWh>;
+    fn sensor_type(&self) -> &'static str {
+        ComputedSensorData::sensor_type(self)
+    }
+    fn to_wh(&self) -> Self::Wh {
+        ComputedSensorData::to_wh(self)
     }
 }
 

--- a/mqtt/src/topics.rs
+++ b/mqtt/src/topics.rs
@@ -1,14 +1,7 @@
-use common::types::SensorData;
-
-pub fn sensor_data_to_topic(id: &str, sensor_data: &SensorData) -> String {
-    let topic = "sensor_data";
-    let type_topic = sensor_data.sensor_type().to_lowercase();
-
-    println!("{type_topic}");
-    format!("{}/{}/{}", id, topic, type_topic)
+pub fn sensor_type_to_topic(id: &str, sensor_type: &str) -> String {
+    format!("{}/sensor_data/{}", id, sensor_type.to_lowercase())
 }
 
 pub fn hardware_info_topic(id: &str) -> String {
-    let topic = "hardware_info";
-    format!("{}/{}", id, topic)
+    format!("{}/hardware_info", id)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ struct Options {
     mqtt_id: Option<String>,
     mqtt_addr: Option<SocketAddr>,
     mqtt_unit: Option<ConsumptionUnit>,
+    mqtt_raw: bool,
     db_mode: bool,
     #[cfg(target_os = "windows")]
     install_cpu_driver: bool,
@@ -82,6 +83,10 @@ fn options() -> OptionParser<Options> {
         })
         .optional();
 
+    let mqtt_raw = long("mqtt-raw")
+        .help("Publish directly raw (non-computed) sensor data.")
+        .switch();
+
     let db_mode = long("no-db")
         .help("Do not save sensors metrics in local database.")
         .flag(false, true);
@@ -105,6 +110,7 @@ fn options() -> OptionParser<Options> {
             mqtt_id,
             mqtt_addr,
             mqtt_unit,
+            mqtt_raw,
             db_mode,
             install_cpu_driver,
             uninstall_cpu_driver,
@@ -122,6 +128,7 @@ fn options() -> OptionParser<Options> {
             mqtt_id,
             mqtt_addr,
             mqtt_unit,
+            mqtt_raw,
             db_mode,
         })
         .to_options()
@@ -324,7 +331,7 @@ fn main() {
     let mqtt_infos = if let Some(mqtt_addr) = options.mqtt_addr {
         let id = options.mqtt_id.unwrap_or("wattseal_collector".to_string());
         let unit = options.mqtt_unit;
-        Some(MQTTInfo::new(&id, &mqtt_addr, unit))
+        Some(MQTTInfo::new(&id, &mqtt_addr, unit, options.mqtt_raw))
     } else {
         None
     };

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, time::SystemTime};
 
 use chrono::{DateTime, Local};
 use common::{
-    AllTimeData, Database, DatabaseEntry, DatabaseError, HardwareInfo, ProcessData, SensorData, TotalData, UiSettings,
-    generic_name_for_table,
+    AllTimeData, ComputedSensorData, Database, DatabaseEntry, DatabaseError, HardwareInfo, ProcessData, TotalData,
+    UiSettings, generic_name_for_table,
 };
 use iced::{
     Alignment, Element, Length, Subscription, Task, event,
@@ -394,11 +394,11 @@ impl App {
         }
     }
 
-    fn load_latest_data(&mut self, n: i64) -> Vec<(DateTime<Local>, SensorData)> {
+    fn load_latest_data(&mut self, n: i64) -> Vec<(DateTime<Local>, ComputedSensorData)> {
         from_db(self.database.select_last_n_records(n))
     }
 
-    fn load_history(&mut self, table_name: &str, time_range: TimeRange) -> Vec<(DateTime<Local>, SensorData)> {
+    fn load_history(&mut self, table_name: &str, time_range: TimeRange) -> Vec<(DateTime<Local>, ComputedSensorData)> {
         if table_name == ProcessData::table_name_static() {
             return self.load_process_data(time_range);
         }
@@ -417,7 +417,7 @@ impl App {
         from_db(result)
     }
 
-    fn load_process_data(&mut self, time_range: TimeRange) -> Vec<(DateTime<Local>, SensorData)> {
+    fn load_process_data(&mut self, time_range: TimeRange) -> Vec<(DateTime<Local>, ComputedSensorData)> {
         from_db(self.database.select_top_processes_average(time_range.seconds(), 10))
     }
 
@@ -632,10 +632,15 @@ impl App {
                     };
 
                     proc_row = proc_row.push(
-                        Text::new(format!("{} ({:.1} {})", top_proc.app_name, value, range.power_unit()))
-                            .size(FONT_SIZE_SUBTITLE)
-                            .font(FONT_BOLD)
-                            .class(TextStyle::Primary),
+                        Text::new(format!(
+                            "{} ({:.1} {})",
+                            top_proc.measured.app_name,
+                            value,
+                            range.power_unit()
+                        ))
+                        .size(FONT_SIZE_SUBTITLE)
+                        .font(FONT_BOLD)
+                        .class(TextStyle::Primary),
                     );
 
                     content = content.push(proc_row);
@@ -913,7 +918,9 @@ impl App {
     }
 }
 
-fn from_db(data: Result<Vec<(SystemTime, SensorData)>, DatabaseError>) -> Vec<(DateTime<Local>, SensorData)> {
+fn from_db(
+    data: Result<Vec<(SystemTime, ComputedSensorData)>, DatabaseError>,
+) -> Vec<(DateTime<Local>, ComputedSensorData)> {
     data.unwrap_or_default()
         .into_iter()
         .map(|(ts, data)| (ts.into(), data))

--- a/ui/src/components/sensor_state.rs
+++ b/ui/src/components/sensor_state.rs
@@ -7,8 +7,8 @@ use std::{
 
 use chrono::{DateTime, Duration, Local, Timelike};
 use common::{
-    DatabaseEntry, DiskData, EnergyUj, IconData, MetricKind, NetworkData, ProcessData, RamData, SecondaryValues,
-    SensorData, TotalData, database::LIVE_SAMPLING_PERIOD_SECONDS, utils::load_icon_and_name,
+    ComputedSensorData, DatabaseEntry, DiskData, EnergyUj, IconData, MetricKind, NetworkData, ProcessData, RamData,
+    SecondaryValues, TotalData, database::LIVE_SAMPLING_PERIOD_SECONDS, utils::load_icon_and_name,
 };
 use iced::{
     Alignment, ContentFit, Element, Length, Padding, Task,
@@ -141,7 +141,7 @@ impl ComponentState {
         }
     }
 
-    fn append(&mut self, timestamp: DateTime<Local>, data: &SensorData, time_range: &TimeRange) {
+    fn append(&mut self, timestamp: DateTime<Local>, data: &ComputedSensorData, time_range: &TimeRange) {
         if let Some(energy) = data.total_energy() {
             self.power_graph
                 .append_power(timestamp, chart_power_or_energy(energy, time_range) as f32);
@@ -228,7 +228,7 @@ impl ComponentState {
         }
     }
 
-    fn available_metrics(&self, latest: Option<&SensorData>) -> Vec<MetricKind> {
+    fn available_metrics(&self, latest: Option<&ComputedSensorData>) -> Vec<MetricKind> {
         let mut metrics = vec![MetricKind::default()];
         if let Some(secondary_values) = latest.and_then(|d| d.secondary_values()) {
             metrics.push(secondary_values.metric_type);
@@ -238,7 +238,7 @@ impl ComponentState {
 
     fn snapshot_row(
         &self,
-        latest: Option<&SensorData>,
+        latest: Option<&ComputedSensorData>,
         language: AppLanguage,
     ) -> Option<Row<'static, Message, AppTheme>> {
         let secondary_values = latest?.secondary_values()?;
@@ -288,7 +288,7 @@ impl TotalState {
         }
     }
 
-    fn append(&self, timestamp: DateTime<Local>, data: &SensorData, time_range: &TimeRange) {
+    fn append(&self, timestamp: DateTime<Local>, data: &ComputedSensorData, time_range: &TimeRange) {
         if let Some(energy) = data.total_energy() {
             self.power_graph
                 .append_power(timestamp, chart_power_or_energy(energy, time_range) as f32);
@@ -329,7 +329,7 @@ impl ProcessesState {
         let mut next_top = processes.to_vec();
 
         for process in &mut next_top {
-            if let Some(exe_path) = &process.process_exe_path {
+            if let Some(exe_path) = &process.measured.process_exe_path {
                 let path = Path::new(exe_path);
                 if !path.is_absolute() {
                     continue;
@@ -343,7 +343,7 @@ impl ProcessesState {
                 });
                 process.icon = entry.0.clone();
                 if let Some(ref friendly_name) = entry.1 {
-                    process.app_name = friendly_name.clone();
+                    process.measured.app_name = friendly_name.clone();
                 }
             }
         }
@@ -383,7 +383,7 @@ pub struct SensorState {
     table_name: String,
     display_name: String,
     sensor_category: SensorCategory,
-    latest_reading: Option<SensorData>,
+    latest_reading: Option<ComputedSensorData>,
     time_range: TimeRange,
     language: AppLanguage,
 }
@@ -422,7 +422,7 @@ impl SensorState {
     }
 
     /// Returns the most recent sensor reading.
-    pub fn get_latest_reading(&self) -> Option<&SensorData> {
+    pub fn get_latest_reading(&self) -> Option<&ComputedSensorData> {
         self.latest_reading.as_ref()
     }
 
@@ -512,7 +512,7 @@ impl SensorState {
     }
 
     /// Appends a real-time data point to the chart.
-    pub fn push_data(&mut self, timestamp: DateTime<Local>, data: &SensorData) {
+    pub fn push_data(&mut self, timestamp: DateTime<Local>, data: &ComputedSensorData) {
         if matches!(self.sensor_category, SensorCategory::Processes(_)) {
             return;
         }
@@ -542,7 +542,7 @@ impl SensorState {
     }
 
     /// Adds a data point to history without updating the latest reading.
-    pub fn push_to_history_only(&mut self, timestamp: DateTime<Local>, data: &SensorData) {
+    pub fn push_to_history_only(&mut self, timestamp: DateTime<Local>, data: &ComputedSensorData) {
         let timestamp = timestamp.with_nanosecond(0).unwrap_or(timestamp);
         match &mut self.sensor_category {
             SensorCategory::Component(state) => state.append(timestamp, data, &self.time_range),
@@ -552,9 +552,9 @@ impl SensorState {
     }
 
     /// Replaces chart data with a full history batch.
-    pub fn load_history_batch(&mut self, data: &[(DateTime<Local>, SensorData)]) {
+    pub fn load_history_batch(&mut self, data: &[(DateTime<Local>, ComputedSensorData)]) {
         if let SensorCategory::Processes(state) = &mut self.sensor_category {
-            if let Some((_, SensorData::Process(processes))) = data.last() {
+            if let Some((_, ComputedSensorData::Process(processes))) = data.last() {
                 state.update_from_snapshot(processes);
             }
             return;
@@ -823,6 +823,7 @@ impl SensorState {
         let table_font_size = FONT_SIZE_BODY;
         for p in &state.top_processes {
             let gpu = p
+                .measured
                 .process_gpu_usage
                 .map_or(na(self.language).to_string(), |v| format!("{:.1}%", v));
             table = table.push(
@@ -831,7 +832,7 @@ impl SensorState {
                     .align_y(Alignment::Center)
                     .push(process_icon_cell(state.icon_handle_for(p)))
                     .push(text_widget(
-                        format!("{} ({})", p.app_name, p.subprocess_count),
+                        format!("{} ({})", p.measured.app_name, p.subprocess_count),
                         table_font_size,
                         TextStyle::Primary,
                         Length::Fixed(PROCESS_APP_WIDTH),
@@ -849,7 +850,7 @@ impl SensorState {
                         true,
                     ))
                     .push(text_widget(
-                        format!("{:.1}%", p.process_cpu_usage),
+                        format!("{:.1}%", p.measured.process_cpu_usage),
                         table_font_size,
                         TextStyle::Secondary,
                         Length::Fixed(PROCESS_CPU_WIDTH),
@@ -863,21 +864,21 @@ impl SensorState {
                         false,
                     ))
                     .push(text_widget(
-                        format!("{:.1}%", p.process_mem_usage),
+                        format!("{:.1}%", p.measured.process_mem_usage),
                         table_font_size,
                         TextStyle::Secondary,
                         Length::Fixed(PROCESS_RAM_WIDTH),
                         false,
                     ))
                     .push(text_widget(
-                        format!("{:.1}MB/s", p.read_bytes.as_mb()),
+                        format!("{:.1}MB/s", p.measured.read_bytes.as_mb()),
                         table_font_size,
                         TextStyle::Secondary,
                         Length::Fixed(PROCESS_DISK_READ_WIDTH),
                         false,
                     ))
                     .push(text_widget(
-                        format!("{:.1}MB/s", p.written_bytes.as_mb()),
+                        format!("{:.1}MB/s", p.measured.written_bytes.as_mb()),
                         table_font_size,
                         TextStyle::Tertiary,
                         Length::Fixed(PROCESS_DISK_WRITE_WIDTH),
@@ -987,10 +988,11 @@ fn process_power_or_energy(energy: EnergyUj, time_range: &TimeRange) -> f64 {
 
 fn process_identity(process: &ProcessData) -> String {
     process
+        .measured
         .process_exe_path
         .as_ref()
         .cloned()
-        .unwrap_or_else(|| process.app_name.clone())
+        .unwrap_or_else(|| process.measured.app_name.clone())
 }
 
 fn prune_history(history: &HistoryRef, cutoff: DateTime<Local>) {

--- a/ui/src/message.rs
+++ b/ui/src/message.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Local};
-use common::{MetricKind, SensorData};
+use common::{ComputedSensorData, MetricKind};
 
 use crate::{
     pages::Page,
@@ -22,8 +22,8 @@ pub enum Message {
     CloseSettings,
     ChangeChartMetricType(String, MetricKind),
     ChangeChartTimeRange(String, TimeRange),
-    UpdateChartData(Vec<(DateTime<Local>, SensorData)>),
-    ReplaceChartData(String, Vec<(DateTime<Local>, SensorData)>),
+    UpdateChartData(Vec<(DateTime<Local>, ComputedSensorData)>),
+    ReplaceChartData(String, Vec<(DateTime<Local>, ComputedSensorData)>),
     FetchChartData(String, TimeRange),
     FetchAllChartsData(TimeRange),
     Redraw,


### PR DESCRIPTION
## Description

Split raw measurements from sensors (CPU, GPU, RAM, disk, network and measured processes) from the computed ones (previous ones + total and grouped estimated processes).

## Related issues

Closes #74 #60 

## Changes

- Rename SensorData into ComputedSensorData (that was indeed already computed)
- Add a new SensorData struct to hold only measured data and add MeasuredProcessData for processes only
- Split the measurement of SensorData and the computation
- Add a `mqtt-raw` cli option to send only the raw data and skip computation
- Not in the scope: fix and simplify the sql query for process data in the UI to display correct values

## Checklist

- [x] `cargo build` passes
- [x] `cargo +nightly fmt` applied
- [x] Changes are scoped to the described issue
