### PR TITLE
feat: autostart on windows boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "winreg",
 ]
 
 [[package]]
@@ -6600,6 +6601,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/collector/src/sensors/cpu/windows_cpu/driver.rs
+++ b/collector/src/sensors/cpu/windows_cpu/driver.rs
@@ -66,22 +66,6 @@ impl MsrDriverReader {
     }
 }
 
-impl Drop for MsrDriverReader {
-    /// Security specific for WinRing0: close and uninstall the driver when the reader is dropped.
-    fn drop(&mut self) {
-        crate::clog!("Closing WinRing0 driver...");
-        match self.driver.close() {
-            Ok(_) => crate::clog!("WinRing0 driver closed successfully."),
-            Err(e) => crate::clog!("Error closing WinRing0 driver: {}", e),
-        }
-        crate::clog!("Uninstalling WinRing0 driver...");
-        match Self::uninstall() {
-            Ok(_) => crate::clog!("WinRing0 driver uninstalled successfully."),
-            Err(e) => crate::clog!("Error uninstalling WinRing0 driver: {}", e),
-        }
-    }
-}
-
 fn extract_windows_error_code(message: &str) -> Option<u32> {
     let code_prefix = "(code ";
     if let Some(start) = message.find(code_prefix) {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,3 +14,4 @@ image = { version = "0.25", default-features = false, features = ["png", "ico"] 
 
 [target."cfg(windows)".dependencies]
 pelite = "0.10.0"
+winreg = "0.56.0"

--- a/common/src/autostart.rs
+++ b/common/src/autostart.rs
@@ -1,0 +1,59 @@
+//! Registers/unregisters WattSeal to launch automatically when the user logs in.
+//!
+//! Windows is backed by the per-user `Run` registry key (no admin rights required).
+//! Other platforms are not yet supported and report the feature as unavailable.
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use winreg::{RegKey, enums::HKEY_CURRENT_USER};
+
+    const RUN_KEY_PATH: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
+    const VALUE_NAME: &str = "WattSeal";
+
+    /// Returns `true` if a startup entry for WattSeal exists in the registry.
+    pub fn is_enabled() -> bool {
+        let Ok(hkcu) = RegKey::predef(HKEY_CURRENT_USER).open_subkey(RUN_KEY_PATH) else {
+            return false;
+        };
+        hkcu.get_value::<String, _>(VALUE_NAME).is_ok()
+    }
+
+    /// Adds or removes the WattSeal startup registry entry.
+    ///
+    /// When enabling, the entry launches the current executable in background
+    /// mode (tray icon only), matching how the app behaves when auto-started.
+    pub fn set_enabled(enabled: bool) -> Result<(), String> {
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let (key, _) = hkcu.create_subkey(RUN_KEY_PATH).map_err(|e| e.to_string())?;
+
+        if enabled {
+            let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+            let command = format!("\"{}\" --background", exe.display());
+            key.set_value(VALUE_NAME, &command).map_err(|e| e.to_string())
+        } else {
+            match key.delete_value(VALUE_NAME) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(e) => Err(e.to_string()),
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod platform {
+    pub fn is_enabled() -> bool {
+        false
+    }
+
+    pub fn set_enabled(_enabled: bool) -> Result<(), String> {
+        Err("Launch on startup is currently only supported on Windows".to_string())
+    }
+}
+
+pub use platform::{is_enabled, set_enabled};
+
+/// Returns `true` if launch-on-startup is supported on this platform.
+pub const fn is_supported() -> bool {
+    cfg!(target_os = "windows")
+}

--- a/common/src/autostart.rs
+++ b/common/src/autostart.rs
@@ -29,11 +29,19 @@ mod platform {
         if enabled {
             let exe = std::env::current_exe().map_err(|e| e.to_string())?;
             let command = format!("\"{}\" --background", exe.display());
-            key.set_value(VALUE_NAME, &command).map_err(|e| e.to_string())
+            key.set_value(VALUE_NAME, &command).map_err(|e| e.to_string())?;
+            crate::clog!("\u{2713} Registered launch-on-startup entry {RUN_KEY_PATH}\\{VALUE_NAME} = {command}");
+            Ok(())
         } else {
             match key.delete_value(VALUE_NAME) {
-                Ok(()) => Ok(()),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Ok(()) => {
+                    crate::clog!("\u{2713} Removed launch-on-startup entry {RUN_KEY_PATH}\\{VALUE_NAME}");
+                    Ok(())
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    crate::clog!("\u{2713} Launch-on-startup entry {RUN_KEY_PATH}\\{VALUE_NAME} already absent");
+                    Ok(())
+                }
                 Err(e) => Err(e.to_string()),
             }
         }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod autostart;
 pub mod database;
 pub mod logging;
 pub mod singleton;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -352,7 +352,10 @@ impl App {
             }
             Message::ToggleLaunchOnStartup(enabled) => {
                 match common::autostart::set_enabled(enabled) {
-                    Ok(()) => self.launch_on_startup = enabled,
+                    Ok(()) => {
+                        self.launch_on_startup = enabled;
+                        common::clog!("✓ Launch-on-startup {}", if enabled { "enabled" } else { "disabled" });
+                    }
                     Err(e) => common::clog!("✗ Failed to update launch-on-startup setting: {e}"),
                 }
                 Task::none()

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -55,6 +55,7 @@ pub struct App {
     custom_carbon_input: String,
     electricity_cost: ElectricityCost,
     custom_kwh_cost_input: String,
+    launch_on_startup: bool,
     show_setup: bool,
     header: Header,
     footer: Footer,
@@ -141,6 +142,7 @@ impl App {
                 custom_carbon_input,
                 electricity_cost,
                 custom_kwh_cost_input,
+                launch_on_startup: common::autostart::is_enabled(),
                 show_setup,
                 theme,
                 database,
@@ -175,6 +177,7 @@ impl App {
                 custom_carbon_input: String::new(),
                 electricity_cost: ElectricityCost::PRESETS[8],
                 custom_kwh_cost_input: String::new(),
+                launch_on_startup: common::autostart::is_enabled(),
                 show_setup: false,
                 theme,
                 database,
@@ -347,6 +350,13 @@ impl App {
                 self.persist_ui_settings();
                 Task::none()
             }
+            Message::ToggleLaunchOnStartup(enabled) => {
+                match common::autostart::set_enabled(enabled) {
+                    Ok(()) => self.launch_on_startup = enabled,
+                    Err(e) => common::clog!("✗ Failed to update launch-on-startup setting: {e}"),
+                }
+                Task::none()
+            }
             Message::ChangeChartMetricType(table_name, metric_type) => {
                 if let Some(sensor) = self.sensors.get_mut(&table_name) {
                     sensor.set_metric_type(metric_type);
@@ -489,6 +499,7 @@ impl App {
                     &self.custom_carbon_input,
                     self.electricity_cost,
                     &self.custom_kwh_cost_input,
+                    self.launch_on_startup,
                 ),
                 Message::CloseSettings,
             )

--- a/ui/src/message.rs
+++ b/ui/src/message.rs
@@ -18,6 +18,7 @@ pub enum Message {
     ChangeElectricityCost(ElectricityCost),
     CustomKwhCostInput(String),
     ChangeCustomCurrency(Currency),
+    ToggleLaunchOnStartup(bool),
     OpenSettings,
     CloseSettings,
     ChangeChartMetricType(String, MetricKind),

--- a/ui/src/pages/settings.rs
+++ b/ui/src/pages/settings.rs
@@ -1,6 +1,6 @@
 use iced::{
     Alignment, Element, Length,
-    widget::{Button, Column, Container, Row, Text, button, pick_list, text_input},
+    widget::{Button, Column, Container, Row, Text, button, pick_list, text_input, toggler},
 };
 
 use crate::{
@@ -13,13 +13,14 @@ use crate::{
             SPACING_LARGE,
         },
         text::TextStyle,
+        toggler::TogglerStyle,
     },
     themes::AppTheme,
     translations::{
         TranslatedCarbonIntensity, TranslatedElectricityCost, TranslatedTheme, custom_carbon_invalid,
         custom_carbon_placeholder, custom_kwh_cost_placeholder, kwh_cost_invalid, modal_close,
-        settings_carbon_intensity, settings_electricity_cost, settings_general, settings_language, settings_theme,
-        settings_title,
+        settings_carbon_intensity, settings_electricity_cost, settings_general, settings_language,
+        settings_launch_on_startup, settings_theme, settings_title,
     },
     types::{AppLanguage, CarbonIntensity, Currency, ElectricityCost},
 };
@@ -40,6 +41,7 @@ impl SettingsPage {
         custom_carbon_input: &'a str,
         electricity_cost: ElectricityCost,
         custom_kwh_cost_input: &'a str,
+        launch_on_startup: bool,
     ) -> Element<'a, Message, AppTheme> {
         let title = Text::new(settings_title(language))
             .size(FONT_SIZE_HEADER)
@@ -83,15 +85,19 @@ impl SettingsPage {
             .push(title)
             .push(close_button);
 
-        let content = Column::new()
+        let mut content = Column::new()
             .spacing(SPACING_LARGE)
             .align_x(Alignment::Start)
             .push(top_row)
             .push(subtitle)
             .push(theme_row)
-            .push(language_row)
-            .push(carbon_row)
-            .push(kwh_row);
+            .push(language_row);
+
+        if common::autostart::is_supported() {
+            content = content.push(launch_on_startup_row(language, launch_on_startup));
+        }
+
+        let content = content.push(carbon_row).push(kwh_row);
 
         Container::new(content)
             .width(Length::Fixed(520.0))
@@ -109,6 +115,16 @@ fn settings_row<'a>(label: &'a str, control: Element<'a, Message, AppTheme>) -> 
         .push(Text::new(label).size(FONT_SIZE_BODY).width(Length::FillPortion(2)))
         .push(control)
         .into()
+}
+
+fn launch_on_startup_row<'a>(language: AppLanguage, launch_on_startup: bool) -> Element<'a, Message, AppTheme> {
+    settings_row(
+        settings_launch_on_startup(language),
+        toggler(launch_on_startup)
+            .on_toggle(Message::ToggleLaunchOnStartup)
+            .class(TogglerStyle::Standard)
+            .into(),
+    )
 }
 
 fn carbon_intensity_row<'a>(

--- a/ui/src/translations.rs
+++ b/ui/src/translations.rs
@@ -69,6 +69,15 @@ pub fn settings_language(language: AppLanguage) -> &'static str {
     }
 }
 
+pub fn settings_launch_on_startup(language: AppLanguage) -> &'static str {
+    match language {
+        AppLanguage::English => "Launch on startup",
+        AppLanguage::French => "Lancer au démarrage",
+        AppLanguage::Chinese => "开机自启动",
+        AppLanguage::Romanian => "Pornește la conectare",
+    }
+}
+
 pub fn modal_close(language: AppLanguage) -> &'static str {
     match language {
         AppLanguage::English => "Close",


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does. -->

## Related issue

Closes #101 

## Changes

- Added feature to autostart the application when Windows boots up. Uses the background flag to determine whether it should start minimzed or not.
- The feature is togglable from the Settings dialog.

> Note: Elevation rights still required to run the app.

## Checklist

- [x] `cargo build` passes
- [x] `cargo +nightly fmt` applied
- [x] Changes are scoped to the described issue

## TODOs

- [ ] create tickets to implement this for linux & mac
