### PR TITLE
feat: show hardware models in component title tooltips

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -41,7 +41,8 @@ use crate::{
 const FPS: u64 = 1;
 
 fn non_empty_string(value: &str) -> Option<String> {
-    (!value.trim().is_empty()).then(|| value.to_string())
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 /// Main application state managing pages, sensors, and database.
@@ -122,7 +123,14 @@ impl App {
                 let hardware_model = if table_name == CPUData::table_name_static() {
                     non_empty_string(&hardware_info.cpu.name)
                 } else if table_name == GPUData::table_name_static() {
-                    non_empty_string(&hardware_info.gpus.join(", "))
+                    non_empty_string(
+                        &hardware_info
+                            .gpus
+                            .iter()
+                            .filter_map(|name| non_empty_string(name))
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    )
                 } else {
                     None
                 };

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, time::SystemTime};
 
 use chrono::{DateTime, Local};
 use common::{
-    AllTimeData, ComputedSensorData, Database, DatabaseEntry, DatabaseError, HardwareInfo, ProcessData, TotalData,
-    UiSettings, generic_name_for_table,
+    AllTimeData, CPUData, ComputedSensorData, Database, DatabaseEntry, DatabaseError, GPUData, HardwareInfo,
+    ProcessData, TotalData, UiSettings, generic_name_for_table,
 };
 use iced::{
     Alignment, Element, Length, Subscription, Task, event,
@@ -39,6 +39,10 @@ use crate::{
 };
 
 const FPS: u64 = 1;
+
+fn non_empty_string(value: &str) -> Option<String> {
+    (!value.trim().is_empty()).then(|| value.to_string())
+}
 
 /// Main application state managing pages, sensors, and database.
 pub struct App {
@@ -107,6 +111,7 @@ impl App {
             String::new()
         };
 
+        let hardware_info = database.get_hardware_info().unwrap_or_default();
         let sensors = database
             .get_tables()
             .into_iter()
@@ -114,13 +119,19 @@ impl App {
                 let display_name = generic_name_for_table(table_name.as_str())
                     .map(|s| s.to_string())
                     .unwrap_or(table_name.clone());
+                let hardware_model = if table_name == CPUData::table_name_static() {
+                    non_empty_string(&hardware_info.cpu.name)
+                } else if table_name == GPUData::table_name_static() {
+                    non_empty_string(&hardware_info.gpus.join(", "))
+                } else {
+                    None
+                };
                 (
                     table_name.clone(),
-                    SensorState::new(table_name, display_name, theme, language),
+                    SensorState::new(table_name, display_name, hardware_model, theme, language),
                 )
             })
             .collect();
-        let hardware_info = database.get_hardware_info().unwrap_or_default();
         let dashboard_page = DashboardPage;
         let all_time_data = database.get_all_time_data().unwrap_or_default();
         let task = Task::done(Message::FetchAllChartsData(TimeRange::default()));

--- a/ui/src/components/sensor_state.rs
+++ b/ui/src/components/sensor_state.rs
@@ -30,8 +30,8 @@ use crate::{
         picklist::PickListStyle,
         scrollable::ScrollableStyle,
         style_constants::{
-            FONT_BOLD, FONT_SIZE_BODY, FONT_SIZE_SUBTITLE, PADDING_LARGE, SPACING_LARGE, SPACING_MEDIUM, SPACING_SMALL,
-            SPACING_XLARGE,
+            FONT_BOLD, FONT_SIZE_BODY, FONT_SIZE_SMALL, FONT_SIZE_SUBTITLE, PADDING_LARGE, SPACING_LARGE,
+            SPACING_MEDIUM, SPACING_SMALL, SPACING_XLARGE,
         },
         text::TextStyle,
     },
@@ -388,6 +388,7 @@ enum SensorCategory {
 pub struct SensorState {
     table_name: String,
     display_name: String,
+    hardware_model: Option<String>,
     sensor_category: SensorCategory,
     latest_reading: Option<SensorRecord>,
     time_range: TimeRange,
@@ -396,7 +397,13 @@ pub struct SensorState {
 
 impl SensorState {
     /// Creates a sensor state for the given table and display name.
-    pub fn new(table_name: String, display_name: String, theme: AppTheme, language: AppLanguage) -> Self {
+    pub fn new(
+        table_name: String,
+        display_name: String,
+        hardware_model: Option<String>,
+        theme: AppTheme,
+        language: AppLanguage,
+    ) -> Self {
         let sensor_category = if table_name == TotalData::table_name_static() {
             SensorCategory::Total(TotalState::new(theme, &display_name, language))
         } else if table_name == ProcessData::table_name_static() {
@@ -408,6 +415,7 @@ impl SensorState {
         let mut state = Self {
             table_name,
             display_name,
+            hardware_model,
             sensor_category,
             latest_reading: None,
             time_range: TimeRange::default(),
@@ -679,10 +687,14 @@ impl SensorState {
         extra_control: Option<Element<'b, Message, AppTheme>>,
     ) -> Row<'b, Message, AppTheme> {
         let default_name = sensor_name(self.language, &self.display_name);
-        let title_widget = Text::new(title.unwrap_or(default_name))
-            .size(FONT_SIZE_SUBTITLE)
-            .font(FONT_BOLD)
-            .width(Length::Fill);
+        let mut title_widget = Column::new().spacing(2).width(Length::Fill).push(
+            Text::new(title.unwrap_or(default_name))
+                .size(FONT_SIZE_SUBTITLE)
+                .font(FONT_BOLD),
+        );
+        if let Some(model) = self.hardware_model.as_deref() {
+            title_widget = title_widget.push(Text::new(model).size(FONT_SIZE_SMALL).class(TextStyle::Muted));
+        }
 
         let info_button: Button<'b, Message, AppTheme> = button(Text::new("?").size(FONT_SIZE_BODY).font(FONT_BOLD))
             .class(ButtonStyle::InfoHelp)

--- a/ui/src/components/sensor_state.rs
+++ b/ui/src/components/sensor_state.rs
@@ -15,6 +15,7 @@ use iced::{
     widget::{
         Button, Column, Container, Row, Scrollable, Space, Text, button, image, pick_list,
         scrollable::{Direction, Scrollbar},
+        tooltip,
     },
 };
 
@@ -687,14 +688,23 @@ impl SensorState {
         extra_control: Option<Element<'b, Message, AppTheme>>,
     ) -> Row<'b, Message, AppTheme> {
         let default_name = sensor_name(self.language, &self.display_name);
-        let mut title_widget = Column::new().spacing(2).width(Length::Fill).push(
-            Text::new(title.unwrap_or(default_name))
-                .size(FONT_SIZE_SUBTITLE)
-                .font(FONT_BOLD),
-        );
-        if let Some(model) = self.hardware_model.as_deref() {
-            title_widget = title_widget.push(Text::new(model).size(FONT_SIZE_SMALL).class(TextStyle::Muted));
-        }
+        let title_widget = Text::new(title.unwrap_or(default_name))
+            .size(FONT_SIZE_SUBTITLE)
+            .font(FONT_BOLD);
+        let title_widget: Element<'b, Message, AppTheme> = match self.hardware_model.as_deref() {
+            Some(model) => tooltip(
+                title_widget,
+                Container::new(Text::new(model).size(FONT_SIZE_SMALL)).max_width(320),
+                tooltip::Position::Bottom,
+            )
+            .class(ContainerStyle::Card)
+            .padding(SPACING_SMALL)
+            .gap(SPACING_SMALL)
+            .delay(std::time::Duration::from_millis(350))
+            .into(),
+            None => title_widget.into(),
+        };
+        let title_widget = Container::new(title_widget).width(Length::Fill);
 
         let info_button: Button<'b, Message, AppTheme> = button(Text::new("?").size(FONT_SIZE_BODY).font(FONT_BOLD))
             .class(ButtonStyle::InfoHelp)


### PR DESCRIPTION
Hovering the CPU or GPU component title now shows the detected hardware models in a tooltip, keeping the card header compact at the default window size.

- Use Iced's existing tooltip widget with a short hover delay and the current theme's card styling.
- Show each detected GPU model on its own line and wrap long names within a 320 px content limit.
- Trim model names and omit empty entries; cards without a reported model have no tooltip.
- Preserve aggregate CPU/GPU charts and existing hardware information details.
- Integrate the current main branch, including the process-count selector.

Validation: `cargo +nightly fmt -- --check`, `cargo test -p common -p ui --locked`, and `cargo build -p ui --locked` pass. The locally built Windows UI was checked at the default window size for CPU and GPU tooltips. The full application build is currently blocked locally because the installed `msr-driver-rs 1.0.1` dependency is missing `WinRing0x64.sys`; the UI build succeeds independently.
